### PR TITLE
feat(sdk): Phase 4 — typed subscribe_to_compaction_updates

### DIFF
--- a/packages/sdks/maximem-synap/maximem_synap/sdk.py
+++ b/packages/sdks/maximem-synap/maximem_synap/sdk.py
@@ -4,6 +4,7 @@ import asyncio
 import json
 import logging
 import os
+import threading
 from datetime import datetime, timezone
 from typing import Any, Callable, Dict, List, Optional
 
@@ -337,6 +338,42 @@ def _merge_local_st_into_response(
         logger.warning("Failed to attach merged conversation_context to response: %s", e)
 
 
+def _dispatch_compaction_subscribers(
+    sdk: "MaximemSynapSDK",
+    conversation_id: str,
+    bundle_dict: Dict[str, Any],
+) -> None:
+    """Invoke every subscriber registered for this conversation_id with the
+    fired bundle. Both sync and async callables are accepted; async ones are
+    scheduled via ``asyncio.create_task``. Exceptions are caught and logged
+    so a single misbehaving subscriber can't break the gRPC reader loop or
+    the other subscribers.
+    """
+    if not conversation_id:
+        return
+    with sdk._compaction_subscribers_lock:
+        callbacks = list(sdk._compaction_subscribers.get(conversation_id, []))
+    if not callbacks:
+        return
+    for cb in callbacks:
+        try:
+            if asyncio.iscoroutinefunction(cb):
+                try:
+                    asyncio.create_task(cb(bundle_dict))
+                except RuntimeError:
+                    # No running loop (sync caller dispatching into async cb).
+                    logger.debug(
+                        "compaction subscriber %r is async but no event loop "
+                        "is running; skipping", cb,
+                    )
+            else:
+                cb(bundle_dict)
+        except Exception as e:
+            logger.warning(
+                "compaction subscriber %r raised on dispatch: %s", cb, e,
+            )
+
+
 def _extract_served_item_ids(anticipated: Dict) -> List[str]:
     """Pull item ids out of an anticipation cache lookup result."""
     ids: List[str] = []
@@ -668,6 +705,14 @@ class MaximemSynapSDK:
         # instance_id. None = not-yet-checked. Refreshed opportunistically
         # via `_refresh_st_authoritative_flag()`.
         self._st_authoritative_enabled: Optional[bool] = None
+
+        # Phase 4 — typed compaction-update subscribers (per-conversation
+        # callbacks fired when a `compaction_update` bundle arrives on the
+        # Listen stream). Keyed by conversation_id → list of callables.
+        # Maintained by ConversationContextInterface.subscribe_to_compaction_updates;
+        # dispatched from InstanceInterface._handle_anticipated_bundle.
+        self._compaction_subscribers: Dict[str, List[Callable[[Dict[str, Any]], Any]]] = {}
+        self._compaction_subscribers_lock = threading.RLock()
 
         self._turn_counters: Dict[str, int] = {}
         self._user_summary_interval: int = 5
@@ -1411,6 +1456,91 @@ class ConversationContextInterface:
 
     def __init__(self, sdk: MaximemSynapSDK):
         self._sdk = sdk
+
+    # ------------------------------------------------------------------
+    # Phase 4: typed compaction-update subscription
+    # ------------------------------------------------------------------
+
+    def subscribe_to_compaction_updates(
+        self,
+        conversation_id: str,
+        callback: Callable[[Dict[str, Any]], Any],
+    ) -> Callable[[], None]:
+        """Register ``callback`` to fire whenever a ``compaction_update``
+        bundle arrives on the Listen stream for ``conversation_id``.
+
+        Without this typed API, callers had to subscribe to every bundle
+        via ``sdk.instance.listen(on_context=...)`` and filter for
+        ``_bundle_type == "compaction_update"`` themselves. This wraps that
+        for the common case.
+
+        Multiple callbacks can be registered for the same conversation;
+        they fire in registration order. Both sync and ``async def``
+        callables are accepted — async ones are scheduled via
+        ``asyncio.create_task`` (and silently skipped if no event loop
+        is running, matching the standard SDK callback contract).
+
+        Returns an ``unsubscribe()`` thunk that removes this specific
+        subscription. Calling it more than once is a no-op.
+
+        Args:
+            conversation_id: Conversation to subscribe to. Must be non-empty.
+            callback: Receives the raw bundle dict (same shape passed to
+                ``on_context``). The ``conversation_context`` sub-dict
+                carries the compaction's ``summary``, ``compaction_id``,
+                ``end_timestamp``, etc.
+
+        Returns:
+            Callable that removes this subscription when invoked.
+
+        Raises:
+            InvalidInputError: If ``conversation_id`` is empty.
+        """
+        if not conversation_id:
+            raise InvalidInputError("conversation_id is required")
+        if callback is None:
+            raise InvalidInputError("callback is required")
+
+        sdk = self._sdk
+        with sdk._compaction_subscribers_lock:
+            subs = sdk._compaction_subscribers.setdefault(conversation_id, [])
+            subs.append(callback)
+
+        unsubscribed = [False]
+
+        def unsubscribe() -> None:
+            if unsubscribed[0]:
+                return
+            unsubscribed[0] = True
+            with sdk._compaction_subscribers_lock:
+                subs2 = sdk._compaction_subscribers.get(conversation_id)
+                if not subs2:
+                    return
+                try:
+                    subs2.remove(callback)
+                except ValueError:
+                    pass
+                if not subs2:
+                    sdk._compaction_subscribers.pop(conversation_id, None)
+
+        return unsubscribe
+
+    def unsubscribe_all_compaction_updates(
+        self, conversation_id: Optional[str] = None
+    ) -> int:
+        """Remove subscribers. If ``conversation_id`` is provided, only
+        subscribers for that conversation are removed; otherwise every
+        subscriber across every conversation is removed. Returns the
+        count removed.
+        """
+        sdk = self._sdk
+        with sdk._compaction_subscribers_lock:
+            if conversation_id is None:
+                count = sum(len(v) for v in sdk._compaction_subscribers.values())
+                sdk._compaction_subscribers.clear()
+                return count
+            popped = sdk._compaction_subscribers.pop(conversation_id, None)
+            return len(popped) if popped else 0
 
     async def fetch(
         self,
@@ -2615,6 +2745,11 @@ class InstanceInterface:
                     )
                 except Exception:
                     pass  # Non-critical
+
+                # Phase 4: dispatch to typed subscribers for this conversation.
+                # Failures in user callbacks are swallowed and logged so a
+                # bad listener can't break the stream-reader loop.
+                _dispatch_compaction_subscribers(self._sdk, conv_id, bundle_dict)
 
         # Always invoke user callback regardless of type
         if hasattr(self, "_on_context_callback") and self._on_context_callback:

--- a/tests/sdk/test_phase4_compaction_subscribers.py
+++ b/tests/sdk/test_phase4_compaction_subscribers.py
@@ -1,0 +1,206 @@
+"""Unit tests for Phase 4 typed compaction-update subscriptions."""
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from maximem_synap.cache.anticipation_cache import AnticipationCache
+from maximem_synap.cache.short_term_store import ShortTermContextStore
+from maximem_synap.models.errors import InvalidInputError
+from maximem_synap.sdk import (
+    ConversationContextInterface,
+    InstanceInterface,
+    _dispatch_compaction_subscribers,
+)
+
+
+def _make_sdk():
+    """A minimal SDK-shaped object the subscribe API can sit on."""
+    sdk = MagicMock()
+    sdk._compaction_subscribers = {}
+    import threading
+    sdk._compaction_subscribers_lock = threading.RLock()
+    sdk._st_store = ShortTermContextStore()
+    sdk._anticipation_cache = AnticipationCache()
+    sdk._cache_manager = MagicMock()
+    sdk._cache_manager.delete = MagicMock()
+    sdk._is_st_authoritative = lambda: True
+    return sdk
+
+
+def _compaction_bundle(conversation_id: str = "c1") -> dict:
+    return {
+        "_bundle_type": "compaction_update",
+        "_anticipation_conversation_id": conversation_id,
+        "conversation_context": {
+            "conversation_id": conversation_id,
+            "summary": "the summary",
+            "compaction_id": "comp-x",
+            "end_timestamp": "2026-05-22T10:00:00+00:00",
+        },
+    }
+
+
+class TestSubscribeBasic:
+    def test_subscribe_requires_conversation_id(self):
+        sdk = _make_sdk()
+        cci = ConversationContextInterface(sdk)
+        with pytest.raises(InvalidInputError):
+            cci.subscribe_to_compaction_updates("", lambda b: None)
+
+    def test_subscribe_requires_callback(self):
+        sdk = _make_sdk()
+        cci = ConversationContextInterface(sdk)
+        with pytest.raises(InvalidInputError):
+            cci.subscribe_to_compaction_updates("c1", None)  # type: ignore[arg-type]
+
+    def test_subscribe_and_dispatch_fires_sync_callback(self):
+        sdk = _make_sdk()
+        cci = ConversationContextInterface(sdk)
+        received = []
+        cci.subscribe_to_compaction_updates("c1", lambda b: received.append(b))
+        _dispatch_compaction_subscribers(sdk, "c1", _compaction_bundle("c1"))
+        assert len(received) == 1
+        assert received[0]["conversation_context"]["summary"] == "the summary"
+
+    def test_dispatch_to_other_conversation_is_noop(self):
+        sdk = _make_sdk()
+        cci = ConversationContextInterface(sdk)
+        received = []
+        cci.subscribe_to_compaction_updates("c1", lambda b: received.append(b))
+        _dispatch_compaction_subscribers(sdk, "c2", _compaction_bundle("c2"))
+        assert received == []
+
+    def test_multiple_subscribers_fire_in_order(self):
+        sdk = _make_sdk()
+        cci = ConversationContextInterface(sdk)
+        order = []
+        cci.subscribe_to_compaction_updates("c1", lambda b: order.append("a"))
+        cci.subscribe_to_compaction_updates("c1", lambda b: order.append("b"))
+        cci.subscribe_to_compaction_updates("c1", lambda b: order.append("c"))
+        _dispatch_compaction_subscribers(sdk, "c1", _compaction_bundle())
+        assert order == ["a", "b", "c"]
+
+    def test_unsubscribe_removes_only_that_callback(self):
+        sdk = _make_sdk()
+        cci = ConversationContextInterface(sdk)
+        a_calls = []
+        b_calls = []
+        un_a = cci.subscribe_to_compaction_updates("c1", lambda b: a_calls.append(1))
+        cci.subscribe_to_compaction_updates("c1", lambda b: b_calls.append(1))
+        un_a()
+        _dispatch_compaction_subscribers(sdk, "c1", _compaction_bundle())
+        assert a_calls == []
+        assert b_calls == [1]
+
+    def test_unsubscribe_is_idempotent(self):
+        sdk = _make_sdk()
+        cci = ConversationContextInterface(sdk)
+        un = cci.subscribe_to_compaction_updates("c1", lambda b: None)
+        un()
+        un()  # should not raise
+        # Re-dispatching shouldn't fire anything
+        received = []
+        un2 = cci.subscribe_to_compaction_updates("c1", lambda b: received.append(1))
+        _dispatch_compaction_subscribers(sdk, "c1", _compaction_bundle())
+        assert received == [1]
+
+    def test_subscriber_exception_does_not_break_others(self):
+        sdk = _make_sdk()
+        cci = ConversationContextInterface(sdk)
+        bad_called = []
+        good_called = []
+
+        def bad(_b):
+            bad_called.append(1)
+            raise RuntimeError("boom")
+
+        cci.subscribe_to_compaction_updates("c1", bad)
+        cci.subscribe_to_compaction_updates("c1", lambda b: good_called.append(1))
+        _dispatch_compaction_subscribers(sdk, "c1", _compaction_bundle())
+        assert bad_called == [1]
+        assert good_called == [1]
+
+
+class TestUnsubscribeAll:
+    def test_unsubscribe_all_for_conv(self):
+        sdk = _make_sdk()
+        cci = ConversationContextInterface(sdk)
+        cci.subscribe_to_compaction_updates("c1", lambda b: None)
+        cci.subscribe_to_compaction_updates("c1", lambda b: None)
+        cci.subscribe_to_compaction_updates("c2", lambda b: None)
+        removed = cci.unsubscribe_all_compaction_updates("c1")
+        assert removed == 2
+        assert "c1" not in sdk._compaction_subscribers
+        assert len(sdk._compaction_subscribers.get("c2", [])) == 1
+
+    def test_unsubscribe_all_global(self):
+        sdk = _make_sdk()
+        cci = ConversationContextInterface(sdk)
+        cci.subscribe_to_compaction_updates("c1", lambda b: None)
+        cci.subscribe_to_compaction_updates("c2", lambda b: None)
+        cci.subscribe_to_compaction_updates("c3", lambda b: None)
+        removed = cci.unsubscribe_all_compaction_updates()
+        assert removed == 3
+        assert sdk._compaction_subscribers == {}
+
+
+class TestAsyncCallback:
+    def test_async_callback_dispatched_via_create_task(self):
+        sdk = _make_sdk()
+        cci = ConversationContextInterface(sdk)
+        received = []
+
+        async def cb(bundle):
+            received.append(bundle)
+
+        async def run():
+            cci.subscribe_to_compaction_updates("c1", cb)
+            _dispatch_compaction_subscribers(sdk, "c1", _compaction_bundle())
+            await asyncio.sleep(0)  # let the task run
+            assert len(received) == 1
+
+        asyncio.run(run())
+
+
+class TestEndToEndViaInstanceHandler:
+    """Exercise the full path: bundle arrives at InstanceInterface._handle_anticipated_bundle,
+    which routes compaction_update through the dispatcher."""
+
+    def test_handler_dispatches_to_subscribers(self):
+        # Use the SDK directly so the wiring under test is real, not mocked.
+        from maximem_synap import MaximemSynapSDK
+
+        sdk = MaximemSynapSDK(instance_id="inst-x", api_key="dummy", _force_new=True)
+        cci = ConversationContextInterface(sdk)
+        instance = InstanceInterface(sdk)
+        instance._on_context_callback = None
+
+        fired = []
+        cci.subscribe_to_compaction_updates("c1", lambda b: fired.append(b))
+
+        instance._handle_anticipated_bundle(_compaction_bundle("c1"))
+        assert len(fired) == 1
+        assert fired[0]["conversation_context"]["compaction_id"] == "comp-x"
+
+    def test_handler_skips_non_compaction_bundles(self):
+        from maximem_synap import MaximemSynapSDK
+
+        sdk = MaximemSynapSDK(instance_id="inst-y", api_key="dummy", _force_new=True)
+        cci = ConversationContextInterface(sdk)
+        instance = InstanceInterface(sdk)
+        instance._on_context_callback = None
+
+        fired = []
+        cci.subscribe_to_compaction_updates("c1", lambda b: fired.append(b))
+
+        anticipation_bundle = {
+            "_bundle_type": "anticipation",
+            "_anticipation_conversation_id": "c1",
+            "items": [],
+        }
+        instance._handle_anticipated_bundle(anticipation_bundle)
+        assert fired == []


### PR DESCRIPTION
## Summary

Quality-of-life extension of the SDK-authoritative ST work. Without this, callers wanting to react to compactions had to subscribe to every bundle via `sdk.instance.listen(on_context=...)` and filter for `_bundle_type == 'compaction_update'` themselves.

```python
unsubscribe = sdk.conversation.context.subscribe_to_compaction_updates(
    conversation_id="...",
    callback=lambda bundle: print("compaction landed:", bundle["conversation_context"]["compaction_id"]),
)
# ... later ...
unsubscribe()
```

- Sync + async callbacks both accepted; async ones via `asyncio.create_task`.
- Per-conversation registration; multiple subscribers fire in registration order.
- Subscriber exceptions are caught + logged so one bad listener can't break the gRPC reader loop or other subscribers.
- `unsubscribe_all_compaction_updates(conv_id=None)` for bulk teardown.
- Hook is one line inside `InstanceInterface._handle_anticipated_bundle`; the existing `on_context` callback still fires unchanged.

## Test plan

- [x] 13 new unit tests covering input validation, single/multiple subscribers, unsubscribe (idempotent), unsubscribe_all (per-conv + global), async dispatch via `create_task`, subscriber-exception isolation, and an end-to-end test that wires the real `InstanceInterface` handler.
- [x] Full SDK suite now 57 tests, all green.
- [ ] Post-merge smoke: spin up SDK, register subscriber, push a synthetic compaction_update through the real gRPC handler, verify callback fires once.