### PR TITLE
fix(sdk): honor SYNAP_BASE_URL / SYNAP_GRPC_* env vars at init

### DIFF
--- a/packages/sdks/maximem-synap/maximem_synap/models/config.py
+++ b/packages/sdks/maximem-synap/maximem_synap/models/config.py
@@ -37,7 +37,7 @@ class SDKConfig(BaseModel):
     api_base_url: Optional[str] = None  # Override default API base URL
     grpc_host: Optional[str] = None  # Override default gRPC host
     grpc_port: Optional[int] = None  # Override default gRPC port (e.g. 50051)
-    grpc_use_tls: bool = True  # Set False for plaintext connections (testing)
+    grpc_use_tls: Optional[bool] = None  # None=use transport default (TLS on); False=plaintext
     storage_path: Optional[str] = None  # Override default cache path (~/.synap/)
     cache_backend: Optional[str] = "sqlite"  # "sqlite" or None
     session_timeout_minutes: int = Field(default=30, ge=5, le=1440)

--- a/packages/sdks/maximem-synap/maximem_synap/sdk.py
+++ b/packages/sdks/maximem-synap/maximem_synap/sdk.py
@@ -681,6 +681,33 @@ class MaximemSynapSDK:
         self.instance_id = instance_id or os.environ.get("SYNAP_INSTANCE_ID", "")
         self._api_key = api_key
         self._config = config or SDKConfig()
+        # Env-var fallbacks for transport endpoints. Priority:
+        # explicit SDKConfig field > env var > hardcoded transport default.
+        # Lets clients point a fresh SDK at staging/dev without instantiating
+        # SDKConfig — matches the SYNAP_API_KEY / SYNAP_INSTANCE_ID pattern.
+        if self._config.api_base_url is None:
+            env_base = os.environ.get("SYNAP_BASE_URL", "").strip()
+            if env_base:
+                self._config.api_base_url = env_base
+        if self._config.grpc_host is None:
+            env_host = os.environ.get("SYNAP_GRPC_HOST", "").strip()
+            if env_host:
+                self._config.grpc_host = env_host
+        if self._config.grpc_port is None:
+            env_port = os.environ.get("SYNAP_GRPC_PORT", "").strip()
+            if env_port:
+                try:
+                    self._config.grpc_port = int(env_port)
+                except ValueError:
+                    logger.warning(
+                        "Ignoring non-integer SYNAP_GRPC_PORT=%r", env_port
+                    )
+        if self._config.grpc_use_tls is None:
+            env_tls = os.environ.get("SYNAP_GRPC_USE_TLS", "").strip().lower()
+            if env_tls in {"1", "true", "yes", "on"}:
+                self._config.grpc_use_tls = True
+            elif env_tls in {"0", "false", "no", "off"}:
+                self._config.grpc_use_tls = False
         self._initialized = False
 
         # Components (initialized lazily or in initialize())
@@ -2665,11 +2692,14 @@ class InstanceInterface:
 
     def _create_transport(self, **kwargs) -> GRPCTransport:
         """Factory that creates a GRPCTransport with SDK configuration."""
+        # grpc_use_tls is Optional[bool]: None means "use transport default"
+        # (TLS on). False means caller explicitly wants plaintext.
+        cfg_tls = self._sdk._config.grpc_use_tls
         transport = GRPCTransport(
             instance_id=self._sdk.instance_id,
             host=self._sdk._config.grpc_host,
             port=self._sdk._config.grpc_port,
-            use_tls=self._sdk._config.grpc_use_tls,
+            use_tls=True if cfg_tls is None else cfg_tls,
             timeouts=self._sdk._config.timeouts,
             telemetry_callback=self._sdk._on_telemetry_event,
             **kwargs,

--- a/tests/sdk/test_env_var_resolution.py
+++ b/tests/sdk/test_env_var_resolution.py
@@ -1,0 +1,111 @@
+"""SDK transport endpoint resolution from env vars.
+
+Verifies that MaximemSynapSDK honors SYNAP_BASE_URL / SYNAP_GRPC_HOST /
+SYNAP_GRPC_PORT / SYNAP_GRPC_USE_TLS, with priority:
+
+  explicit SDKConfig field  >  env var  >  hardcoded transport default.
+
+Mirrors the SYNAP_API_KEY / SYNAP_INSTANCE_ID env-var pattern already
+established elsewhere in the SDK.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from maximem_synap.sdk import MaximemSynapSDK
+from maximem_synap.models.config import SDKConfig
+
+
+_ENV_KEYS = (
+    "SYNAP_BASE_URL",
+    "SYNAP_GRPC_HOST",
+    "SYNAP_GRPC_PORT",
+    "SYNAP_GRPC_USE_TLS",
+    "SYNAP_INSTANCE_ID",
+    "SYNAP_API_KEY",
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    for k in _ENV_KEYS:
+        monkeypatch.delenv(k, raising=False)
+    monkeypatch.setenv("SYNAP_API_KEY", "fake-for-tests")
+
+
+def test_env_vars_populate_unset_config():
+    os.environ["SYNAP_BASE_URL"] = "https://staging.example.com"
+    os.environ["SYNAP_GRPC_HOST"] = "grpc-staging.example.com"
+    os.environ["SYNAP_GRPC_PORT"] = "443"
+    os.environ["SYNAP_GRPC_USE_TLS"] = "true"
+
+    sdk = MaximemSynapSDK(instance_id="t1", _force_new=True)
+
+    assert sdk._config.api_base_url == "https://staging.example.com"
+    assert sdk._config.grpc_host == "grpc-staging.example.com"
+    assert sdk._config.grpc_port == 443
+    assert sdk._config.grpc_use_tls is True
+
+
+def test_explicit_config_beats_env_var():
+    os.environ["SYNAP_BASE_URL"] = "https://env.example.com"
+    os.environ["SYNAP_GRPC_USE_TLS"] = "true"
+
+    sdk = MaximemSynapSDK(
+        instance_id="t2",
+        config=SDKConfig(
+            api_base_url="https://explicit.example.com",
+            grpc_host="ex.host",
+            grpc_port=50051,
+            grpc_use_tls=False,
+        ),
+        _force_new=True,
+    )
+    assert sdk._config.api_base_url == "https://explicit.example.com"
+    assert sdk._config.grpc_host == "ex.host"
+    assert sdk._config.grpc_port == 50051
+    assert sdk._config.grpc_use_tls is False
+
+
+def test_nothing_set_leaves_none_for_transport_default():
+    sdk = MaximemSynapSDK(instance_id="t3", _force_new=True)
+    assert sdk._config.api_base_url is None
+    assert sdk._config.grpc_host is None
+    assert sdk._config.grpc_port is None
+    # None at SDKConfig level — call-site resolves to True (transport default).
+    assert sdk._config.grpc_use_tls is None
+
+
+def test_garbage_port_ignored_with_warning(caplog):
+    os.environ["SYNAP_GRPC_PORT"] = "not-a-port"
+    sdk = MaximemSynapSDK(instance_id="t4", _force_new=True)
+    assert sdk._config.grpc_port is None
+
+
+def test_env_tls_false_honored():
+    os.environ["SYNAP_GRPC_USE_TLS"] = "false"
+    sdk = MaximemSynapSDK(instance_id="t5", _force_new=True)
+    assert sdk._config.grpc_use_tls is False
+
+
+def test_env_tls_accepts_common_truthy_strings():
+    for truthy in ("1", "true", "TRUE", "yes", "on"):
+        os.environ["SYNAP_GRPC_USE_TLS"] = truthy
+        sdk = MaximemSynapSDK(instance_id=f"t_{truthy}", _force_new=True)
+        assert sdk._config.grpc_use_tls is True, (
+            f"{truthy!r} should resolve to True"
+        )
+
+
+def test_http_transport_base_url_propagation():
+    from maximem_synap.transport.http_client import HTTPTransport
+
+    os.environ["SYNAP_BASE_URL"] = "https://probe.example.com"
+    sdk = MaximemSynapSDK(instance_id="t6", _force_new=True)
+
+    # Mirror what SDK.initialize() does: construct transport from config.
+    t = HTTPTransport(instance_id="t6", base_url=sdk._config.api_base_url)
+    assert t.base_url == "https://probe.example.com"


### PR DESCRIPTION
## Summary

Today the SDK reads `SYNAP_API_KEY` / `SYNAP_INSTANCE_ID` from env but the **transport endpoints** (`api_base_url`, `grpc_host`, `grpc_port`, `grpc_use_tls`) are only read from explicit `SDKConfig`. Callers without `SDKConfig(api_base_url=...)` always hit the hardcoded `synap-cloud-prod.maximem.ai` default — even with `SYNAP_BASE_URL` set in their environment.

Caught during the 2026-05-22 short-term context rollout session (see `docs/internal/sdk_authoritative_short_term_context_plan.md`) — the local SDK probe couldn't reach staging without explicit `SDKConfig(api_base_url=...)`, which is friction we shouldn't ship.

## After this change

Resolution order, matching the existing `SYNAP_API_KEY` pattern:

```
explicit SDKConfig field  >  env var  >  hardcoded transport default
```

Env vars only fill in fields the caller left unset. Explicit config still wins.

## Subtle: `grpc_use_tls` schema change

Was `bool = True` — no "unset" state, so any env-var override would unconditionally beat an explicit `grpc_use_tls=False`. Switched to `Optional[bool] = None`; call sites translate `None → True` when invoking `GRPCTransport`. On-the-wire TLS-on default is unchanged.

## Test plan

- [x] 7 new tests in `tests/sdk/test_env_var_resolution.py` covering all precedence orderings, accepted truthy/falsy strings, garbage-port graceful handling, and HTTPTransport propagation — all green.
- [x] Verified `MaximemSynapSDK(...)` against staging now works with just `SYNAP_BASE_URL=https://synap-cloud-staging.maximem.ai` in env, no explicit `SDKConfig`.
- [ ] Pre-existing failures in `test_short_term_store.py::TestAppendTurn::test_explicit_timestamp_is_used` and `test_phase2_local_st_merge.py::TestMergeLocalSTIntoResponse::test_merges_recent_turns` reproduce on `main` with these changes stashed — unrelated, tracked separately. They do not block this PR.

## Note on CI

`main` CI has been broken since 2026-05-09 (workflow references `packages/maximem-synap` instead of `packages/sdks/maximem-synap`). This PR will show UNSTABLE for the same reason — not introduced here.