### PR TITLE
feat(synap-langgraph): short-term context adapter (canonical template)

### DIFF
--- a/packages/integrations/synap-langgraph/README.md
+++ b/packages/integrations/synap-langgraph/README.md
@@ -18,6 +18,89 @@ Requires `langgraph>=1.0`, `maximem-synap>=0.2.0`.
 
 - **`create_synap_node`** — re-exported from `synap-langchain` for users who discovered our LangGraph support through the LangChain package. This is the canonical home.
 
+- **`synap_st_prompt`** — short-term conversation context as a `prompt` callable for `create_react_agent`. Prepends Synap's compacted summary + recent turns above your system prompt at every LLM step.
+
+- **`create_synap_st_node`** — same short-term context, exposed as a `StateGraph` node that writes the ST string into state for your LLM node to consume.
+
+## Short-term context (compacted conversation, on every LLM step)
+
+LangGraph's built-in memory truncates recent turns to a token budget. Synap's short-term context is the **compacted summary + recent turns** maintained per conversation by the Synap server — a richer, more token-efficient view of "what happened so far." Drop it into a prebuilt agent or a custom graph; both helpers serve from the SDK's local cache when warm (near-zero overhead) and fall back to the Synap server when cold.
+
+The SDK helper they both wrap is `sdk.conversation.context.get_context_for_prompt(conv_id, style=...)`, which is cache-first whenever the `SYNAP_SDK_ST_AUTHORITATIVE` flag is on.
+
+### A) Prebuilt agent — one-line drop-in
+
+```python
+from langgraph.prebuilt import create_react_agent  # or langchain.agents.create_agent
+from maximem_synap import MaximemSynapSDK
+from synap_langgraph import synap_st_prompt
+
+sdk = MaximemSynapSDK(api_key="sk-...")
+
+agent = create_react_agent(
+    model="anthropic:claude-3-5-sonnet-20241022",
+    tools=[...],
+    prompt=synap_st_prompt(
+        sdk,
+        conversation_id="conv_abc123",       # required, explicit
+        system="You are a helpful agent.",   # your own instructions
+        style="narrative",                   # default; also "structured" | "bullet_points"
+    ),
+)
+```
+
+What the model sees at every step (system message content):
+
+```
+<synap_short_term_context>
+... compacted summary + recent turns from Synap ...
+</synap_short_term_context>
+
+You are a helpful agent.
+```
+
+### B) Custom graph — write ST into state, consume in your own LLM node
+
+```python
+from typing import Annotated, TypedDict
+from langgraph.graph import StateGraph, START, END
+from langgraph.graph.message import add_messages
+from synap_langgraph import create_synap_st_node
+
+class State(TypedDict):
+    messages: Annotated[list, add_messages]
+    synap_st: str   # populated by the node
+
+async def my_llm_node(state: State):
+    system_text = f"You are a helpful agent.\n\n{state['synap_st']}".strip()
+    ...   # build your prompt template with system_text and invoke the model
+
+graph = StateGraph(State)
+graph.add_node("st", create_synap_st_node(sdk, conversation_id="conv_abc123"))
+graph.add_node("llm", my_llm_node)
+graph.add_edge(START, "st")
+graph.add_edge("st", "llm")
+graph.add_edge("llm", END)
+```
+
+### Which to use
+
+| You're building... | Use |
+| --- | --- |
+| A prebuilt React-style agent (`create_react_agent` / `create_agent`) | **`synap_st_prompt`** — drop into `prompt=` |
+| A custom `StateGraph` with multi-LLM / conditional routing / per-step prompt composition | **`create_synap_st_node`** — read `state["synap_st"]` in your nodes |
+| Both | They compose — adapter Option A is sugar over Option B + a SystemMessage prepend |
+
+### Error policy
+
+- SDK failures **never crash the graph** by default (`on_error="fallback"`): logged at `ERROR` via `SynapIntegrationError`'s log path, then the helper degrades to your bare system prompt (or empty state slot).
+- Pass `on_error="raise"` for strict environments that want the failure surfaced as `SynapIntegrationError`.
+- An empty short-term result (no compaction yet **and** no recent turns) is a legitimate empty case, not a failure — the user's system prompt is preserved as-is.
+
+### Conversation ID
+
+Always explicit. We deliberately do **not** infer it from LangGraph's `thread_id` because the two namespaces can diverge — your thread might span multiple Synap conversations, or vice versa. For multi-conversation agents, construct one prompt callable per conversation inside your per-run setup.
+
 ## Quickstart
 
 ```python

--- a/packages/integrations/synap-langgraph/synap_langgraph/__init__.py
+++ b/packages/integrations/synap-langgraph/synap_langgraph/__init__.py
@@ -18,10 +18,26 @@ Exposes:
 - :func:`create_synap_node` — re-exported from ``synap_langchain.graph`` for
   continuity with pre-0.1.0 users who discovered our LangGraph support via the
   LangChain package. The canonical home is now this package.
+
+- :func:`synap_st_prompt` — Synap **short-term context** prompt callable for
+  ``create_react_agent(prompt=...)``. Prepends the compacted conversation
+  history (cache-first via ``sdk.conversation.context.get_context_for_prompt``)
+  above the user's system prompt on every LLM step.
+
+- :func:`create_synap_st_node` — same short-term context, exposed as a
+  state-mutating node for custom ``StateGraph`` flows. Writes the ST string
+  into ``state[state_key]`` for downstream LLM nodes to assemble.
 """
 
 from synap_langgraph.store import SynapStore
 from synap_langgraph.checkpointer import SynapCheckpointSaver
+from synap_langgraph.short_term import create_synap_st_node, synap_st_prompt
 from synap_langchain.graph import create_synap_node
 
-__all__ = ["SynapStore", "SynapCheckpointSaver", "create_synap_node"]
+__all__ = [
+    "SynapStore",
+    "SynapCheckpointSaver",
+    "create_synap_node",
+    "create_synap_st_node",
+    "synap_st_prompt",
+]

--- a/packages/integrations/synap-langgraph/synap_langgraph/short_term.py
+++ b/packages/integrations/synap-langgraph/synap_langgraph/short_term.py
@@ -1,0 +1,345 @@
+"""Synap short-term context for LangGraph.
+
+Two composable surfaces, both wrapping
+``sdk.conversation.context.get_context_for_prompt`` (which is cache-first
+behind the ``SYNAP_SDK_ST_AUTHORITATIVE`` flag — see
+``docs/internal/sdk_authoritative_short_term_context_plan.md``):
+
+- :func:`synap_st_prompt` — returns an async callable suitable for
+  ``create_react_agent(prompt=...)``. Prepends the Synap short-term
+  context block above the user's system prompt and returns the full
+  message list LangGraph expects. Use for **prebuilt** agents where the
+  one-line drop-in matters.
+
+- :func:`create_synap_st_node` — returns an async node suitable for
+  ``StateGraph.add_node(...)``. Writes the ST string into
+  ``state[state_key]`` for downstream LLM nodes to assemble however they
+  want. Use for **custom graphs** where you control the prompt template.
+
+Both honour the project-wide policy:
+
+- The ``conversation_id`` is **required** at construction time — explicit
+  caller-supplied. We deliberately do not infer from the LangGraph
+  ``thread_id`` because the two namespaces can diverge.
+- SDK failures **never** crash the graph by default
+  (``on_error="fallback"``): we log via :class:`SynapIntegrationError`'s
+  log path, then degrade to the user's bare system prompt /
+  empty state slot. Pass ``on_error="raise"`` for strict environments.
+- An empty short-term result (no compaction yet **and** no recent turns
+  in the SDK cache) is treated as a no-op — it must not wipe the user's
+  system prompt.
+
+The wire shape (cache-first, server fallback, SDK-authoritative when the
+flag is on) is owned entirely by the SDK helper. These adapters are thin
+shape converters — they intentionally do NOT format, truncate, or
+re-summarise.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Awaitable, Callable, Dict, List, Literal, Optional
+
+from langchain_core.messages import BaseMessage, SystemMessage
+from maximem_synap import MaximemSynapSDK
+from synap_integrations_common import (
+    SynapIntegrationError,
+    wrap_sdk_errors_async,
+)
+
+logger = logging.getLogger(__name__)
+
+# Mirror the SDK formatter's supported styles. We re-validate here so a
+# construction-time typo fails fast instead of surfacing on first agent
+# turn. Kept in sync with maximem_synap.formatter.context_for_prompt —
+# importing the constant directly would couple this package to an
+# internal SDK module path that may move; the trade-off is a single
+# tuple to maintain.
+_SUPPORTED_STYLES = ("structured", "narrative", "bullet_points")
+
+# Default tags wrap the ST block so a model can recognise it as a
+# distinct section. Overridable; setting to ``None`` strips the wrapper
+# entirely (the block then prepends as raw text).
+_DEFAULT_OPEN = "<synap_short_term_context>"
+_DEFAULT_CLOSE = "</synap_short_term_context>"
+
+_OnError = Literal["fallback", "raise"]
+
+
+def _get_state_messages(state: Any) -> List[BaseMessage]:
+    """Read ``messages`` from a state object that may be a dict OR an
+    object with attribute access (LangGraph supports both shapes).
+    """
+    if isinstance(state, dict):
+        return list(state.get("messages") or [])
+    return list(getattr(state, "messages", None) or [])
+
+
+def _validate_args(
+    sdk: Optional[MaximemSynapSDK],
+    conversation_id: str,
+    style: str,
+    on_error: str,
+    site: str,
+) -> None:
+    if sdk is None:
+        raise ValueError(f"{site} requires a non-None sdk")
+    if not conversation_id or not str(conversation_id).strip():
+        raise ValueError(
+            f"{site} requires a non-empty conversation_id "
+            f"(pass it explicitly per-run for multi-conversation agents)"
+        )
+    if style not in _SUPPORTED_STYLES:
+        raise ValueError(
+            f"{site}: unsupported style={style!r}; "
+            f"expected one of {_SUPPORTED_STYLES}"
+        )
+    if on_error not in ("fallback", "raise"):
+        raise ValueError(
+            f"{site}: on_error must be 'fallback' or 'raise', got {on_error!r}"
+        )
+
+
+async def _fetch_st_block(
+    sdk: MaximemSynapSDK,
+    conversation_id: str,
+    style: str,
+    on_error: _OnError,
+    site: str,
+) -> str:
+    """Fetch the formatted short-term context string.
+
+    Returns an **empty string** when no short-term context is available
+    OR when the SDK call fails and ``on_error="fallback"``. Raises
+    :class:`SynapIntegrationError` when the SDK call fails and
+    ``on_error="raise"``.
+    """
+    try:
+        async with wrap_sdk_errors_async(
+            site,
+            logger,
+            conversation_id=conversation_id,
+            style=style,
+        ):
+            response = await sdk.conversation.context.get_context_for_prompt(
+                conversation_id=conversation_id,
+                style=style,
+            )
+    except SynapIntegrationError:
+        if on_error == "raise":
+            raise
+        # wrap_sdk_errors_async already logged at ERROR with full context.
+        return ""
+
+    # The SDK marks ``available=False`` when there is no compaction yet
+    # AND no recent turns — that's a legitimate empty result, not a
+    # failure. Return empty so the caller can keep the user's system
+    # prompt intact.
+    if not getattr(response, "available", False):
+        return ""
+    formatted = getattr(response, "formatted_context", None)
+    return (formatted or "").strip()
+
+
+def _compose_system_prompt(
+    st_block: str,
+    user_system: str,
+    preamble_open: Optional[str],
+    preamble_close: Optional[str],
+) -> str:
+    """Combine ST block + user system prompt into a single string.
+
+    Empty inputs are dropped silently; the result is always a clean
+    string (no double blank lines, no orphan tags, no leading/trailing
+    whitespace). When both inputs are empty we return ``""`` — the
+    caller decides whether to emit a SystemMessage or skip it.
+    """
+    parts: List[str] = []
+    st_block = (st_block or "").strip()
+    user_system = (user_system or "").strip()
+
+    if st_block:
+        if preamble_open and preamble_close:
+            parts.append(f"{preamble_open}\n{st_block}\n{preamble_close}")
+        else:
+            parts.append(st_block)
+    if user_system:
+        parts.append(user_system)
+
+    return "\n\n".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# Public surface — Option 1: prompt callable for create_react_agent
+# ---------------------------------------------------------------------------
+
+
+def synap_st_prompt(
+    sdk: MaximemSynapSDK,
+    conversation_id: str,
+    *,
+    system: str = "",
+    style: str = "narrative",
+    preamble_open: Optional[str] = _DEFAULT_OPEN,
+    preamble_close: Optional[str] = _DEFAULT_CLOSE,
+    on_error: _OnError = "fallback",
+) -> Callable[[Any], Awaitable[List[BaseMessage]]]:
+    """Return an async ``prompt`` callable for ``create_react_agent``.
+
+    On every LLM step the callable:
+
+    1. Awaits :func:`MaximemSynapSDK.conversation.context.get_context_for_prompt`
+       (cache-first; near-zero overhead when the SDK store is warm).
+    2. Prepends the ST block above ``system`` inside the configured
+       preamble tags.
+    3. Returns ``[SystemMessage(content=<combined>), *state.messages]``
+       — the message list LangGraph passes straight to the model.
+
+    Args:
+        sdk: Initialised :class:`MaximemSynapSDK`.
+        conversation_id: Synap conversation ID. **Required.** For
+            multi-conversation agents construct one prompt callable per
+            conversation (typically inside your per-run setup).
+        system: The user's own system prompt. Stays authoritative for
+            behaviour; the ST block is contextual framing prepended
+            above it.
+        style: One of ``"structured" | "narrative" | "bullet_points"``.
+            Defaults to ``"narrative"`` because that reads most cleanly
+            inside a system prompt.
+        preamble_open / preamble_close: Wrapping tags for the ST block.
+            Pass ``None`` for both to drop the tags and prepend raw
+            text. Defaults to a ``<synap_short_term_context>`` XML pair.
+        on_error: ``"fallback"`` (default) logs and returns the bare
+            ``system`` prompt on SDK failure; ``"raise"`` propagates
+            :class:`SynapIntegrationError`.
+
+    Returns:
+        Async callable accepted by ``create_react_agent(prompt=...)``.
+
+    Raises:
+        ValueError: On invalid construction args (caught at agent build
+        time, not at first LLM call).
+
+    Example::
+
+        from langgraph.prebuilt import create_react_agent
+        from maximem_synap import MaximemSynapSDK
+        from synap_langgraph import synap_st_prompt
+
+        sdk = MaximemSynapSDK()
+        agent = create_react_agent(
+            model="anthropic:claude-3-5-sonnet-20241022",
+            tools=[...],
+            prompt=synap_st_prompt(
+                sdk,
+                conversation_id="conv_abc123",
+                system="You are a helpful customer support agent.",
+            ),
+        )
+    """
+    _validate_args(
+        sdk, conversation_id, style, on_error, "synap_st_prompt"
+    )
+
+    async def _prompt(state: Any) -> List[BaseMessage]:
+        st_block = await _fetch_st_block(
+            sdk,
+            conversation_id,
+            style,
+            on_error,
+            site="synap_langgraph.synap_st_prompt",
+        )
+        combined = _compose_system_prompt(
+            st_block, system, preamble_open, preamble_close
+        )
+        messages = _get_state_messages(state)
+        if combined:
+            return [SystemMessage(content=combined), *messages]
+        # No ST, no user system — pass messages through unchanged so the
+        # graph's default behaviour is preserved.
+        return messages
+
+    _prompt.__name__ = "synap_st_prompt"
+    return _prompt
+
+
+# ---------------------------------------------------------------------------
+# Public surface — Option 2: state-mutating node for custom StateGraphs
+# ---------------------------------------------------------------------------
+
+
+def create_synap_st_node(
+    sdk: MaximemSynapSDK,
+    conversation_id: str,
+    *,
+    state_key: str = "synap_st",
+    style: str = "narrative",
+    on_error: _OnError = "fallback",
+) -> Callable[[Dict[str, Any]], Awaitable[Dict[str, Any]]]:
+    """Return an async node that writes the Synap ST string into state.
+
+    Place this node before your LLM node in a custom ``StateGraph``.
+    The LLM node then reads ``state[state_key]`` and composes its own
+    prompt — useful when you need to do something more than "prepend ST
+    above one static system prompt" (e.g. multi-LLM flows, conditional
+    routing, per-step system prompts, structured-output flows that need
+    ST inline rather than in the system slot).
+
+    The node always writes ``state[state_key]``. The value is:
+
+    - the formatted ST string when short-term context exists;
+    - ``""`` when no ST is available yet (no compaction **and** no
+      recent turns), so downstream code can ``if state["synap_st"]:``
+      uniformly;
+    - ``""`` on SDK failure with the default ``on_error="fallback"``;
+      otherwise :class:`SynapIntegrationError` is raised.
+
+    Args:
+        sdk: Initialised :class:`MaximemSynapSDK`.
+        conversation_id: Synap conversation ID. **Required.**
+        state_key: State dict key to write the ST string into.
+            Defaults to ``"synap_st"``.
+        style: One of ``"structured" | "narrative" | "bullet_points"``.
+        on_error: ``"fallback"`` (default) | ``"raise"``.
+
+    Returns:
+        Async node compatible with ``StateGraph.add_node``.
+
+    Example::
+
+        from langgraph.graph import StateGraph, START, END
+        from synap_langgraph import create_synap_st_node
+
+        graph = StateGraph(MyState)
+        graph.add_node("st", create_synap_st_node(sdk, "conv_abc"))
+        graph.add_node("llm", my_llm_node)  # reads state["synap_st"]
+        graph.add_edge(START, "st")
+        graph.add_edge("st", "llm")
+        graph.add_edge("llm", END)
+    """
+    _validate_args(
+        sdk, conversation_id, style, on_error, "create_synap_st_node"
+    )
+    if not state_key or not str(state_key).strip():
+        raise ValueError(
+            "create_synap_st_node requires a non-empty state_key"
+        )
+
+    async def _node(state: Dict[str, Any]) -> Dict[str, Any]:
+        st_block = await _fetch_st_block(
+            sdk,
+            conversation_id,
+            style,
+            on_error,
+            site="synap_langgraph.create_synap_st_node",
+        )
+        return {state_key: st_block}
+
+    _node.__name__ = "synap_st_node"
+    return _node
+
+
+__all__ = [
+    "synap_st_prompt",
+    "create_synap_st_node",
+]

--- a/packages/integrations/synap-langgraph/tests/conftest.py
+++ b/packages/integrations/synap-langgraph/tests/conftest.py
@@ -1,0 +1,26 @@
+"""Pytest conftest for synap-langgraph tests.
+
+Adds the in-repo SDK + integration package paths so tests can run
+without installing wheels.
+"""
+
+import os
+import sys
+
+# In-repo SDK
+sys.path.insert(
+    0,
+    os.path.join(os.path.dirname(__file__), "../../../sdks/maximem-synap"),
+)
+# This integration package
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+# Shared integrations utilities
+sys.path.insert(
+    0,
+    os.path.join(os.path.dirname(__file__), "../../synap-integrations-common"),
+)
+# Sister LangChain package (re-exported by __init__)
+sys.path.insert(
+    0,
+    os.path.join(os.path.dirname(__file__), "../../synap-langchain"),
+)

--- a/packages/integrations/synap-langgraph/tests/test_short_term.py
+++ b/packages/integrations/synap-langgraph/tests/test_short_term.py
@@ -1,0 +1,347 @@
+"""Tests for synap_langgraph.short_term — synap_st_prompt + create_synap_st_node.
+
+Covers:
+- Construction-time argument validation.
+- Cache-hit + cache-miss behaviour against a faked SDK.
+- Empty short-term context must not wipe the user's system prompt.
+- SDK failure: graceful degrade (default) vs strict raise.
+- Async invocation under LangGraph's prompt-callable shape.
+- Conversation-id resolution is strictly explicit (no thread_id inference).
+- State shape support: both dict and attribute access.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from langchain_core.messages import HumanMessage, SystemMessage
+
+from synap_langgraph.short_term import (
+    create_synap_st_node,
+    synap_st_prompt,
+)
+from synap_integrations_common import SynapIntegrationError
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_response(formatted: str | None, available: bool):
+    """Build a stand-in ContextForPromptResponse object (duck-typed).
+
+    The adapter reads only ``available`` + ``formatted_context``, so a
+    MagicMock with those attributes is sufficient and avoids importing
+    the pydantic model (which would change shape independently).
+    """
+    resp = MagicMock()
+    resp.available = available
+    resp.formatted_context = formatted
+    return resp
+
+
+def _fake_sdk(formatted: str | None = "## Summary\nUser likes dark mode.", available: bool = True):
+    sdk = MagicMock()
+    sdk.conversation.context.get_context_for_prompt = AsyncMock(
+        return_value=_make_response(formatted, available)
+    )
+    return sdk
+
+
+def _state_with_messages(*msgs):
+    """LangGraph state is typically a dict with a ``messages`` key."""
+    return {"messages": list(msgs)}
+
+
+# ---------------------------------------------------------------------------
+# Construction-time validation
+# ---------------------------------------------------------------------------
+
+
+class TestPromptValidation:
+    def test_requires_sdk(self):
+        with pytest.raises(ValueError, match="non-None sdk"):
+            synap_st_prompt(None, "conv_abc")  # type: ignore[arg-type]
+
+    def test_requires_conversation_id(self):
+        sdk = _fake_sdk()
+        with pytest.raises(ValueError, match="non-empty conversation_id"):
+            synap_st_prompt(sdk, "")
+        with pytest.raises(ValueError, match="non-empty conversation_id"):
+            synap_st_prompt(sdk, "   ")
+
+    def test_rejects_unknown_style(self):
+        sdk = _fake_sdk()
+        with pytest.raises(ValueError, match="unsupported style"):
+            synap_st_prompt(sdk, "conv_abc", style="poetic")
+
+    def test_accepts_all_documented_styles(self):
+        sdk = _fake_sdk()
+        for style in ("structured", "narrative", "bullet_points"):
+            synap_st_prompt(sdk, "conv_abc", style=style)
+
+    def test_rejects_invalid_on_error(self):
+        sdk = _fake_sdk()
+        with pytest.raises(ValueError, match="on_error"):
+            synap_st_prompt(sdk, "conv_abc", on_error="ignore")  # type: ignore[arg-type]
+
+
+class TestNodeValidation:
+    def test_requires_sdk(self):
+        with pytest.raises(ValueError, match="non-None sdk"):
+            create_synap_st_node(None, "conv_abc")  # type: ignore[arg-type]
+
+    def test_requires_conversation_id(self):
+        sdk = _fake_sdk()
+        with pytest.raises(ValueError, match="non-empty conversation_id"):
+            create_synap_st_node(sdk, "")
+
+    def test_requires_non_empty_state_key(self):
+        sdk = _fake_sdk()
+        with pytest.raises(ValueError, match="non-empty state_key"):
+            create_synap_st_node(sdk, "conv_abc", state_key="")
+
+
+# ---------------------------------------------------------------------------
+# Prompt callable — cache-hit happy path
+# ---------------------------------------------------------------------------
+
+
+class TestPromptCacheHit:
+    @pytest.mark.asyncio
+    async def test_prepends_st_block_above_user_system(self):
+        sdk = _fake_sdk(formatted="User likes concise answers.")
+        prompt = synap_st_prompt(
+            sdk,
+            "conv_abc",
+            system="You are a helpful assistant.",
+        )
+
+        result = await prompt(_state_with_messages(HumanMessage(content="hi")))
+
+        # Expect: [SystemMessage(combined), HumanMessage]
+        assert len(result) == 2
+        assert isinstance(result[0], SystemMessage)
+        assert isinstance(result[1], HumanMessage)
+        content = result[0].content
+        assert "<synap_short_term_context>" in content
+        assert "User likes concise answers." in content
+        assert "</synap_short_term_context>" in content
+        assert "You are a helpful assistant." in content
+        # ST must come first, user system after
+        assert content.index("synap_short_term_context") < content.index("helpful assistant")
+
+    @pytest.mark.asyncio
+    async def test_calls_sdk_with_explicit_conv_and_style(self):
+        sdk = _fake_sdk()
+        prompt = synap_st_prompt(sdk, "conv_abc", style="bullet_points", system="X")
+        await prompt(_state_with_messages())
+        sdk.conversation.context.get_context_for_prompt.assert_awaited_once_with(
+            conversation_id="conv_abc",
+            style="bullet_points",
+        )
+
+    @pytest.mark.asyncio
+    async def test_custom_preamble_used(self):
+        sdk = _fake_sdk(formatted="hello world")
+        prompt = synap_st_prompt(
+            sdk,
+            "conv_abc",
+            system="sys",
+            preamble_open="[BEGIN_ST]",
+            preamble_close="[END_ST]",
+        )
+        result = await prompt(_state_with_messages())
+        assert "[BEGIN_ST]" in result[0].content
+        assert "[END_ST]" in result[0].content
+        assert "<synap_short_term_context>" not in result[0].content
+
+    @pytest.mark.asyncio
+    async def test_no_preamble_means_raw_concat(self):
+        sdk = _fake_sdk(formatted="raw st text")
+        prompt = synap_st_prompt(
+            sdk,
+            "conv_abc",
+            system="sys here",
+            preamble_open=None,
+            preamble_close=None,
+        )
+        result = await prompt(_state_with_messages())
+        assert result[0].content == "raw st text\n\nsys here"
+
+
+# ---------------------------------------------------------------------------
+# Empty ST — the dangerous edge case
+# ---------------------------------------------------------------------------
+
+
+class TestPromptEmptyST:
+    @pytest.mark.asyncio
+    async def test_unavailable_response_does_not_wipe_user_system(self):
+        sdk = _fake_sdk(formatted=None, available=False)
+        prompt = synap_st_prompt(
+            sdk, "conv_abc", system="You are friendly."
+        )
+        result = await prompt(_state_with_messages(HumanMessage(content="hi")))
+
+        # Must still emit the user's system prompt — never silently drop it.
+        assert len(result) == 2
+        assert isinstance(result[0], SystemMessage)
+        assert result[0].content == "You are friendly."
+
+    @pytest.mark.asyncio
+    async def test_empty_formatted_treated_as_unavailable(self):
+        sdk = _fake_sdk(formatted="   ", available=True)
+        prompt = synap_st_prompt(sdk, "conv_abc", system="sys")
+        result = await prompt(_state_with_messages())
+        assert result[0].content == "sys"
+        assert "synap_short_term_context" not in result[0].content
+
+    @pytest.mark.asyncio
+    async def test_both_empty_returns_messages_only(self):
+        sdk = _fake_sdk(formatted=None, available=False)
+        prompt = synap_st_prompt(sdk, "conv_abc", system="")
+        human = HumanMessage(content="hi")
+        result = await prompt(_state_with_messages(human))
+        # No SystemMessage prepended when both ST and user system are empty
+        assert result == [human]
+
+
+# ---------------------------------------------------------------------------
+# Error handling
+# ---------------------------------------------------------------------------
+
+
+class TestPromptErrorHandling:
+    @pytest.mark.asyncio
+    async def test_fallback_returns_user_system_on_sdk_failure(self, caplog):
+        sdk = MagicMock()
+        sdk.conversation.context.get_context_for_prompt = AsyncMock(
+            side_effect=RuntimeError("network blip")
+        )
+        prompt = synap_st_prompt(
+            sdk, "conv_abc", system="Stay calm.", on_error="fallback"
+        )
+        result = await prompt(_state_with_messages(HumanMessage(content="hi")))
+        assert isinstance(result[0], SystemMessage)
+        assert result[0].content == "Stay calm."
+
+    @pytest.mark.asyncio
+    async def test_raise_propagates_synap_integration_error(self):
+        sdk = MagicMock()
+        sdk.conversation.context.get_context_for_prompt = AsyncMock(
+            side_effect=RuntimeError("network blip")
+        )
+        prompt = synap_st_prompt(
+            sdk, "conv_abc", system="X", on_error="raise"
+        )
+        with pytest.raises(SynapIntegrationError) as ei:
+            await prompt(_state_with_messages())
+        assert ei.value.operation == "synap_langgraph.synap_st_prompt"
+        assert isinstance(ei.value.__cause__, RuntimeError)
+
+
+# ---------------------------------------------------------------------------
+# State shape support
+# ---------------------------------------------------------------------------
+
+
+class TestPromptStateShape:
+    @pytest.mark.asyncio
+    async def test_supports_attribute_access_state(self):
+        sdk = _fake_sdk(formatted="ST")
+        prompt = synap_st_prompt(sdk, "conv_abc", system="sys")
+
+        class StateObj:
+            def __init__(self, messages):
+                self.messages = messages
+
+        s = StateObj([HumanMessage(content="hi")])
+        result = await prompt(s)
+        assert len(result) == 2
+        assert result[1].content == "hi"
+
+    @pytest.mark.asyncio
+    async def test_missing_messages_key_treated_as_empty(self):
+        sdk = _fake_sdk(formatted="ST")
+        prompt = synap_st_prompt(sdk, "conv_abc", system="sys")
+        result = await prompt({})  # no messages key at all
+        # Should not crash, should still emit SystemMessage with combined content
+        assert len(result) == 1
+        assert isinstance(result[0], SystemMessage)
+
+
+# ---------------------------------------------------------------------------
+# Node — cache-hit + miss + error
+# ---------------------------------------------------------------------------
+
+
+class TestNode:
+    @pytest.mark.asyncio
+    async def test_writes_st_into_default_state_key(self):
+        sdk = _fake_sdk(formatted="User is on the Pro plan.")
+        node = create_synap_st_node(sdk, "conv_abc")
+        result = await node({})
+        assert result == {"synap_st": "User is on the Pro plan."}
+
+    @pytest.mark.asyncio
+    async def test_writes_into_custom_state_key(self):
+        sdk = _fake_sdk(formatted="hello")
+        node = create_synap_st_node(sdk, "conv_abc", state_key="ctx")
+        result = await node({})
+        assert result == {"ctx": "hello"}
+
+    @pytest.mark.asyncio
+    async def test_empty_st_writes_empty_string(self):
+        sdk = _fake_sdk(formatted=None, available=False)
+        node = create_synap_st_node(sdk, "conv_abc")
+        result = await node({})
+        # Always writes the key so downstream code can `if state["synap_st"]:`
+        assert result == {"synap_st": ""}
+
+    @pytest.mark.asyncio
+    async def test_fallback_on_sdk_failure(self):
+        sdk = MagicMock()
+        sdk.conversation.context.get_context_for_prompt = AsyncMock(
+            side_effect=RuntimeError("boom")
+        )
+        node = create_synap_st_node(sdk, "conv_abc")
+        result = await node({})
+        assert result == {"synap_st": ""}
+
+    @pytest.mark.asyncio
+    async def test_raise_propagates_synap_integration_error(self):
+        sdk = MagicMock()
+        sdk.conversation.context.get_context_for_prompt = AsyncMock(
+            side_effect=RuntimeError("boom")
+        )
+        node = create_synap_st_node(sdk, "conv_abc", on_error="raise")
+        with pytest.raises(SynapIntegrationError):
+            await node({})
+
+    @pytest.mark.asyncio
+    async def test_passes_style_through(self):
+        sdk = _fake_sdk()
+        node = create_synap_st_node(sdk, "conv_abc", style="structured")
+        await node({})
+        sdk.conversation.context.get_context_for_prompt.assert_awaited_once_with(
+            conversation_id="conv_abc",
+            style="structured",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Smoke: imports + public surface
+# ---------------------------------------------------------------------------
+
+
+def test_public_surface_exports():
+    import synap_langgraph
+
+    assert hasattr(synap_langgraph, "synap_st_prompt")
+    assert hasattr(synap_langgraph, "create_synap_st_node")
+    assert "synap_st_prompt" in synap_langgraph.__all__
+    assert "create_synap_st_node" in synap_langgraph.__all__


### PR DESCRIPTION
## Summary

First framework adapter for the SDK-authoritative short-term context flow (Phase 1/2 already shipped — see `docs/internal/sdk_authoritative_short_term_context_plan.md`). This sets the **canonical template** the remaining 17 framework integrations will follow.

Two thin wrappers around `sdk.conversation.context.get_context_for_prompt`:

| Function | LangGraph entry point | When to use |
| --- | --- | --- |
| `synap_st_prompt(sdk, conv_id, system="...", style="narrative")` | `create_react_agent(prompt=...)` / `create_agent(prompt=...)` | Prebuilt agents — one-line drop-in |
| `create_synap_st_node(sdk, conv_id, state_key="synap_st")` | `StateGraph.add_node("st", ...)` | Custom graphs where you control prompt assembly |

Both are **intentionally thin** — the SDK helper owns formatting, cache-first lookup, server fallback, and the `SYNAP_SDK_ST_AUTHORITATIVE` semantics. These adapters only convert shapes.

## Quality bar (locked decisions)

- `conversation_id` is **required + explicit**. We deliberately do not infer from LangGraph `thread_id` — those namespaces can diverge.
- `style` validated against the SDK's `SUPPORTED_STYLES` at construction so a typo fails fast at agent-build time, not first LLM call.
- SDK failures **never crash the graph** by default (`on_error="fallback"`): logged via `SynapIntegrationError`, helper degrades to the bare user system prompt / empty state slot. `on_error="raise"` available for strict environments.
- **Empty ST must not wipe the user's system prompt** — explicitly tested. Treated as legitimate no-op.
- Async-first to match LangGraph 1.x async prompt-callable support; verified end-to-end against the real `create_react_agent` and `StateGraph`.
- Preamble tags (`<synap_short_term_context>...</synap_short_term_context>`) overridable; pass `preamble_open=None, preamble_close=None` for raw concat.

## Test plan

- [x] **26 unit tests** in `tests/test_short_term.py`:
  - Construction validation (5 prompt + 3 node)
  - Cache hit happy path including custom preamble + raw concat
  - **Empty ST handling** (the dangerous edge case)
  - Error policy: fallback (default) vs raise
  - State shape support: dict + attribute access
  - Public surface exports
- [x] **Integration smokes** against real LangGraph 1.x:
  - `create_react_agent(prompt=synap_st_prompt(...))` with FakeMessagesListChatModel
  - `StateGraph.add_node(..., create_synap_st_node(...))` with a custom LLM node consuming `state["synap_st"]`
- [x] README rewritten with quickstarts for both surfaces + when-to-use-which table.

## Note

CI on `main` has been broken since 2026-05-09 (workflow refs `packages/maximem-synap` instead of `packages/sdks/maximem-synap`). Same pre-existing infra issue we admin-merged around for PRs #2 and #3 — this PR will show UNSTABLE for the same reason, not introduced here.