### PR TITLE
fix(sdk): namespace client cache by instance_id; add SYNAP_BASE_URL env

### DIFF
--- a/packages/sdks/maximem-synap/maximem_synap/cache/manager.py
+++ b/packages/sdks/maximem-synap/maximem_synap/cache/manager.py
@@ -42,8 +42,16 @@ class CacheManager:
         client_id: str,
         storage_path: Optional[str] = None,
         enabled: bool = True,
+        instance_id: str = "",
     ):
         self.client_id = client_id
+        # The producing/reading Instance. Customer- and client-scoped cache files
+        # are shared by every Instance under the same client+customer, so the
+        # cache KEY must include instance_id — otherwise two Instances serving the
+        # same customer read each other's entries, silently bypassing server-side
+        # cross-instance visibility (an Instance would see another Instance's
+        # filtered memories straight from the local cache).
+        self.instance_id = instance_id or ""
         self.enabled = enabled
 
         if storage_path:
@@ -91,9 +99,14 @@ class CacheManager:
     ) -> str:
         """Build cache key.
 
-        Format: {client_id}:{scope}:{entity_id}:{context_type}:{query_hash}
+        Format: {client_id}:{instance_id}:{scope}:{entity_id}:{context_type}:{query_hash}
+
+        ``instance_id`` is part of the key so two Instances under the same
+        client+customer (which share the same on-disk cache file) never read
+        each other's entries — preserving cross-instance visibility at the
+        client cache layer.
         """
-        parts = [self.client_id, scope.value, entity_id, context_type]
+        parts = [self.client_id, self.instance_id or "_", scope.value, entity_id, context_type]
         if query_hash:
             parts.append(query_hash)
         return ":".join(parts)
@@ -186,8 +199,9 @@ class CacheManager:
             key = self._build_key(scope, entity_id, context_type, query_hash)
             backend.delete(key)
         else:
-            # Delete all entries for this entity
-            prefix = f"{self.client_id}:{scope.value}:{entity_id}:"
+            # Delete all entries for this entity (scoped to THIS instance, to
+            # match the instance-namespaced key built above).
+            prefix = f"{self.client_id}:{self.instance_id or '_'}:{scope.value}:{entity_id}:"
             backend.clear_scope(prefix)
 
     def clear_user(self, user_id: str) -> None:

--- a/packages/sdks/maximem-synap/maximem_synap/sdk.py
+++ b/packages/sdks/maximem-synap/maximem_synap/sdk.py
@@ -877,11 +877,13 @@ class MaximemSynapSDK:
                 client_id=self._client_id,
                 storage_path=self._config.storage_path,
                 enabled=True,
+                instance_id=self.instance_id,
             )
         else:
             self._cache_manager = CacheManager(
                 client_id=self._client_id,
                 enabled=False,
+                instance_id=self.instance_id,
             )
 
         # Initialize telemetry transport

--- a/packages/sdks/maximem-synap/maximem_synap/transport/http_client.py
+++ b/packages/sdks/maximem-synap/maximem_synap/transport/http_client.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import json
+import os
 import random
 import logging
 from typing import Any, Dict, Optional, Callable
@@ -52,7 +53,10 @@ class HTTPTransport:
         telemetry_callback: Optional[Callable[[Dict], None]] = None,
     ):
         self.instance_id = instance_id
-        self.base_url = base_url or self.DEFAULT_BASE_URL
+        # Precedence: explicit base_url (SDKConfig.api_base_url) > SYNAP_BASE_URL
+        # env var > prod default. The env var lets a deployment target staging
+        # (or any backend) without code changes, matching the JS SDK.
+        self.base_url = base_url or os.environ.get("SYNAP_BASE_URL") or self.DEFAULT_BASE_URL
         self.timeouts = timeouts or TimeoutConfig()
         self.retry_policy = retry_policy
         self.telemetry_callback = telemetry_callback

--- a/tests/sdk/test_cache_key_instance_isolation.py
+++ b/tests/sdk/test_cache_key_instance_isolation.py
@@ -1,0 +1,38 @@
+"""Regression: the client-side CacheManager key must namespace by instance_id.
+
+Customer- and client-scoped cache files are shared by every Instance under the
+same client+customer. If the cache key omits instance_id, a second Instance
+issuing the same query reads the first Instance's cached, visibility-filtered
+context straight from the local cache — silently defeating server-side
+cross-instance visibility. These tests pin the key to include instance_id.
+"""
+from __future__ import annotations
+
+from maximem_synap.cache.manager import CacheManager, CacheScope
+
+
+def _key(mgr: CacheManager) -> str:
+    return mgr._build_key(
+        CacheScope.CUSTOMER, "cust-1", "facts", mgr._hash_query(["same-query"])
+    )
+
+
+def test_distinct_instances_get_distinct_keys():
+    a = CacheManager(client_id="cli_x", enabled=False, instance_id="inst_a")
+    b = CacheManager(client_id="cli_x", enabled=False, instance_id="inst_b")
+    # Same client + customer + type + query, different Instance -> different key.
+    assert _key(a) != _key(b)
+    assert "inst_a" in _key(a)
+    assert "inst_b" in _key(b)
+
+
+def test_same_instance_keeps_stable_key():
+    # Caching still works within one Instance (identical inputs -> identical key).
+    a1 = CacheManager(client_id="cli_x", enabled=False, instance_id="inst_a")
+    a2 = CacheManager(client_id="cli_x", enabled=False, instance_id="inst_a")
+    assert _key(a1) == _key(a2)
+
+
+def test_missing_instance_id_uses_stable_placeholder():
+    m = CacheManager(client_id="cli_x", enabled=False)  # no instance_id
+    assert ":_:" in _key(m)  # empty instance -> "_" placeholder, still a valid key


### PR DESCRIPTION
## Why

Found while verifying **cross-instance memory visibility** end-to-end on staging through the real SDK path the Aiden customer demo uses (`memories.batch_create` + `customer.context.fetch`). The backend feature is correct, but the **SDK's client-side cache silently bypassed it**.

## 1. Client cache bypassed cross-instance visibility (correctness/isolation bug)

`CacheManager` keyed entries `{client_id}:{scope}:{entity_id}:{type}:{qhash}` and stored customer-scoped entries in a **per-customer file shared by every Instance** under that client (`~/.synap/{client}/customers/{customer}.db`). Two Instances serving the same customer therefore computed the **same key in the same file** — the second Instance to issue a given query was served the **first Instance's visibility-filtered context** from the local cache. Result: Instance B reads Instance A's memories, defeating the server-side instance-visibility feature.

**Repro (staging, client cache ON):** B fetches "X" → caches; A fetches "X" → got **B's** filtered result.

**Fix:** thread the SDK's `instance_id` into `CacheManager` and include it in the cache key (key is now `{client_id}:{instance_id}:{scope}:{entity_id}:{type}:{qhash}`; the per-entity delete prefix matches). The on-disk file stays shared; the **key** now separates Instances. **Verified on staging:** with the default client cache ON, two Instances under one client+customer no longer read each other's results (B sees only its own; A sees only its own).

## 2. No env override for API base URL

`base_url` fell back straight to the prod default, so the SDK could only target staging via `SDKConfig(api_base_url=...)`. Added a **`SYNAP_BASE_URL`** env fallback (precedence: explicit arg > env > prod default), matching the JS SDK, so a deployment can point at staging/another backend with no code change. Verified: `MaximemSynapSDK()` with only `SYNAP_BASE_URL` set connects to staging.

## Tests

`tests/sdk/test_cache_key_instance_isolation.py` — distinct Instances → distinct keys; same Instance → stable key (caching preserved); empty `instance_id` → stable placeholder. 3/3 pass.

## Notes

- Backwards-compatible: pre-existing cache entries (without instance_id) simply become misses and expire; no data migration.
- No server changes. Out of scope: the server-side L1 cache already separates Instances correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)