### PR TITLE
fix(sdk): namespaced JS API to match Python SDK + single-source version

### DIFF
--- a/packages/sdks/maximem-synap-js/bridge/synap_bridge.py
+++ b/packages/sdks/maximem-synap-js/bridge/synap_bridge.py
@@ -5,9 +5,9 @@ Protocol:
   stdin  -> {"id": 1, "method": "init", "params": {...}}\n
   stdout <- {"id": 1, "result": {...}, "error": null}\n
 Methods:
-  init, add_memory, search_memory, get_memories, fetch_user_context,
-  fetch_customer_context, fetch_client_context, get_context_for_prompt,
-  delete_memory, shutdown
+  init, add_memory, create_memory, record_message, search_memory,
+  get_memories, fetch_user_context, fetch_customer_context,
+  fetch_client_context, get_context_for_prompt, delete_memory, shutdown
 """
 
 import asyncio
@@ -637,9 +637,88 @@ async def handle_shutdown(_params: dict) -> dict:
     }
 
 
+async def handle_record_message(params: dict) -> dict:
+    """Record a single conversation turn (registers the conversation_id).
+
+    Mirrors the Python SDK's ``sdk.conversation.record_message(...)`` so the
+    JS client can expose the same namespaced surface the integration packages
+    (@maximem/synap-mastra, @maximem/synap-claude-agent) duck-type against.
+    """
+    handler_start = time.perf_counter()
+    timings: List[dict] = []
+    start = time.perf_counter()
+
+    step = time.perf_counter()
+    result = await sdk.conversation.record_message(
+        conversation_id=params["conversation_id"],
+        role=params["role"],
+        content=params["content"],
+        user_id=params["user_id"],
+        customer_id=params["customer_id"],
+        session_id=params.get("session_id"),
+        metadata=params.get("metadata"),
+    )
+    append_step(timings, "record_message", step)
+
+    return {
+        "success": True,
+        "latencyMs": ms_since(start),
+        "result": result,
+        "bridgeTiming": {
+            "python_total_ms": ms_since(handler_start),
+            "steps": timings,
+        },
+    }
+
+
+async def handle_create_memory(params: dict) -> dict:
+    """Create a durable memory from a single document string.
+
+    Mirrors the Python SDK's ``sdk.memories.create(document=...)``. Distinct
+    from ``add_memory``, which builds a transcript from a messages array.
+    """
+    handler_start = time.perf_counter()
+    timings: List[dict] = []
+    start = time.perf_counter()
+
+    create_kwargs: dict = {"document": params["document"]}
+    for key in (
+        "user_id",
+        "customer_id",
+        "document_type",
+        "document_id",
+        "document_created_at",
+        "mode",
+        "metadata",
+    ):
+        if params.get(key) is not None:
+            create_kwargs[key] = params[key]
+
+    step = time.perf_counter()
+    result = await sdk.memories.create(**create_kwargs)
+    append_step(timings, "memories_create", step)
+
+    status = result.status.value if hasattr(result.status, "value") else result.status
+    return {
+        "success": True,
+        "latencyMs": ms_since(start),
+        "result": {
+            "ingestion_id": str(result.ingestion_id),
+            "document_id": result.document_id,
+            "status": status,
+        },
+        "bridgeTiming": {
+            "python_total_ms": ms_since(handler_start),
+            "steps": timings,
+        },
+    }
+
+
 HANDLERS = {
     "init": handle_init,
     "add_memory": handle_add_memory,
+    "create_memory": handle_create_memory,
+    "record_message": handle_record_message,
     "search_memory": handle_search_memory,
     "get_memories": handle_get_memories,
     "fetch_user_context": handle_fetch_user_context,

--- a/packages/sdks/maximem-synap-js/src/synap-client.js
+++ b/packages/sdks/maximem-synap-js/src/synap-client.js
@@ -203,6 +203,7 @@ class SynapClient {
     };
 
     this.#registerShutdownHooks();
+    this.#installNamespacedApi();
   }
 
   async init() {
@@ -357,6 +358,137 @@ class SynapClient {
       await close();
       process.exit(0);
     });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Python-parallel namespaced API.
+  //
+  // The flat methods above (addMemory, fetchUserContext, getContextForPrompt,
+  // ...) return camelCase-normalized objects. The namespaced surface installed
+  // here mirrors the Python SDK 1:1 — sdk.conversation.record_message,
+  // sdk.memories.create, sdk.user/customer/client.context.fetch,
+  // sdk.conversation.context.get_context_for_prompt — and returns the raw
+  // Python response shape (snake_case: formatted_context, facts, preferences,
+  // ingestion_id). This is the surface the integration packages
+  // (@maximem/synap-mastra, @maximem/synap-claude-agent) duck-type against, so
+  // a real client can be passed straight into SynapMemory / createSynapHooks.
+  // Both snake_case and camelCase argument keys are accepted.
+  // ---------------------------------------------------------------------------
+  #installNamespacedApi() {
+    const buildParams = (args = {}) => {
+      const params = {};
+      const conv = pickDefined(args.conversation_id, args.conversationId);
+      const sq = pickDefined(args.search_query, args.searchQuery);
+      const mr = pickDefined(args.max_results, args.maxResults);
+      if (conv !== undefined && conv !== null) params.conversation_id = conv;
+      if (sq !== undefined && sq !== null) params.search_query = sq;
+      if (mr !== undefined) params.max_results = mr;
+      if (args.types !== undefined) params.types = args.types;
+      if (args.mode !== undefined) params.mode = args.mode;
+      return params;
+    };
+
+    // Unified fetch — routes to the scope-appropriate command based on the ids
+    // present (user > customer > client). Returns the raw ContextResponse shape.
+    const fetch = async (args = {}) => {
+      const userId = pickDefined(args.user_id, args.userId);
+      const customerId = pickDefined(args.customer_id, args.customerId);
+      const params = buildParams(args);
+
+      let command;
+      if (userId !== undefined && userId !== null) {
+        command = 'fetch_user_context';
+        params.user_id = userId;
+        if (customerId !== undefined && customerId !== null) params.customer_id = customerId;
+      } else if (customerId !== undefined && customerId !== null) {
+        command = 'fetch_customer_context';
+        params.customer_id = customerId;
+      } else {
+        command = 'fetch_client_context';
+      }
+
+      const result = await this.bridge.call(command, params);
+      return result.context || {};
+    };
+
+    // Explicit per-scope fetchers (sdk.user.context.fetch, etc.).
+    const fetchScope = (command, idKeys) => async (args = {}) => {
+      const params = buildParams(args);
+      if (idKeys.includes('user_id')) {
+        const userId = pickDefined(args.user_id, args.userId);
+        if (userId !== undefined && userId !== null) params.user_id = userId;
+      }
+      if (idKeys.includes('customer_id')) {
+        const customerId = pickDefined(args.customer_id, args.customerId);
+        if (customerId !== undefined && customerId !== null) params.customer_id = customerId;
+      }
+      const result = await this.bridge.call(command, params);
+      return result.context || {};
+    };
+
+    this.fetch = fetch;
+
+    this.conversation = {
+      record_message: async (args = {}) => {
+        const conversationId = pickDefined(args.conversation_id, args.conversationId);
+        const userId = pickDefined(args.user_id, args.userId);
+        const customerId = pickDefined(args.customer_id, args.customerId);
+        this.#assert(conversationId, 'conversation_id is required');
+        this.#assert(userId, 'user_id is required');
+        this.#assert(customerId, 'customer_id is required');
+
+        const params = {
+          conversation_id: conversationId,
+          role: args.role,
+          content: args.content,
+          user_id: userId,
+          customer_id: customerId,
+        };
+        const sessionId = pickDefined(args.session_id, args.sessionId);
+        if (sessionId !== undefined) params.session_id = sessionId;
+        if (args.metadata !== undefined) params.metadata = args.metadata;
+
+        const result = await this.bridge.call('record_message', params);
+        return pickDefined(result.result, result);
+      },
+      context: {
+        get_context_for_prompt: async (args = {}) => {
+          const conversationId = pickDefined(args.conversation_id, args.conversationId);
+          this.#assert(conversationId, 'conversation_id is required');
+          const params = { conversation_id: conversationId };
+          if (args.style !== undefined) params.style = args.style;
+          const result = await this.bridge.call('get_context_for_prompt', params);
+          return pickDefined(result.context_for_prompt, result.contextForPrompt, {});
+        },
+        fetch,
+      },
+    };
+
+    this.memories = {
+      create: async (args = {}) => {
+        this.#assert(args.document, 'document is required');
+        const params = { document: args.document };
+        const userId = pickDefined(args.user_id, args.userId);
+        const customerId = pickDefined(args.customer_id, args.customerId);
+        const documentType = pickDefined(args.document_type, args.documentType);
+        const documentId = pickDefined(args.document_id, args.documentId);
+        const documentCreatedAt = pickDefined(args.document_created_at, args.documentCreatedAt);
+        if (userId !== undefined) params.user_id = userId;
+        if (customerId !== undefined) params.customer_id = customerId;
+        if (documentType !== undefined) params.document_type = documentType;
+        if (documentId !== undefined) params.document_id = documentId;
+        if (documentCreatedAt !== undefined) params.document_created_at = documentCreatedAt;
+        if (args.mode !== undefined) params.mode = args.mode;
+        if (args.metadata !== undefined) params.metadata = args.metadata;
+
+        const result = await this.bridge.call('create_memory', params, this.options.ingestTimeoutMs);
+        return pickDefined(result.result, result);
+      },
+    };
+
+    this.user = { context: { fetch: fetchScope('fetch_user_context', ['user_id', 'customer_id']) } };
+    this.customer = { context: { fetch: fetchScope('fetch_customer_context', ['customer_id']) } };
+    this.client = { context: { fetch: fetchScope('fetch_client_context', []) } };
   }
 }
 

--- a/packages/sdks/maximem-synap-js/types/index.d.ts
+++ b/packages/sdks/maximem-synap-js/types/index.d.ts
@@ -296,6 +296,86 @@ export interface DeleteMemoryResult {
   bridgeTiming?: BridgeTiming;
 }
 
+// ---------------------------------------------------------------------------
+// Python-parallel namespaced API (mirrors the maximem-synap Python SDK).
+// Accepts snake_case or camelCase argument keys; returns the raw Python
+// response shape (snake_case: formatted_context, facts, preferences,
+// ingestion_id, ...). Return types are intentionally loose (`any`) because
+// these calls cross the Python subprocess bridge and must remain assignable to
+// the duck-typed `SynapSdkLike` interfaces that the integration packages
+// (@maximem/synap-mastra, @maximem/synap-claude-agent) define independently.
+// Use the flat methods above (fetchUserContext, getContextForPrompt, ...) for
+// fully-typed camelCase results.
+// ---------------------------------------------------------------------------
+export interface SynapNamespacedFetchInput {
+  userId?: string | null;
+  user_id?: string | null;
+  customerId?: string | null;
+  customer_id?: string | null;
+  conversationId?: string | null;
+  conversation_id?: string | null;
+  searchQuery?: string[] | null;
+  search_query?: string[] | null;
+  maxResults?: number;
+  max_results?: number;
+  types?: string[];
+  mode?: string;
+}
+
+export interface SynapRecordMessageInput {
+  conversationId?: string | null;
+  conversation_id?: string | null;
+  role: string;
+  content: string;
+  userId?: string | null;
+  user_id?: string | null;
+  customerId?: string | null;
+  customer_id?: string | null;
+  sessionId?: string | null;
+  session_id?: string | null;
+  metadata?: Record<string, unknown>;
+}
+
+export interface SynapCreateMemoryInput {
+  document: string;
+  userId?: string | null;
+  user_id?: string | null;
+  customerId?: string | null;
+  customer_id?: string | null;
+  documentType?: string | null;
+  document_type?: string | null;
+  documentId?: string | null;
+  document_id?: string | null;
+  documentCreatedAt?: string | null;
+  document_created_at?: string | null;
+  mode?: string | null;
+  metadata?: Record<string, unknown>;
+}
+
+export interface SynapGetContextForPromptInput {
+  conversationId?: string;
+  conversation_id?: string;
+  style?: string;
+}
+
+export interface SynapScopeContextApi {
+  context: {
+    fetch(input?: SynapNamespacedFetchInput): Promise<any>;
+  };
+}
+
+export interface SynapConversationApi {
+  record_message(input: SynapRecordMessageInput): Promise<any>;
+  context: {
+    get_context_for_prompt(input: SynapGetContextForPromptInput): Promise<any>;
+    fetch(input?: SynapNamespacedFetchInput): Promise<any>;
+  };
+}
+
+export interface SynapMemoriesApi {
+  create(input: SynapCreateMemoryInput): Promise<any>;
+}
+
 export class SynapClient {
   constructor(options?: SynapClientOptions);
   init(): Promise<void>;
@@ -308,6 +388,16 @@ export class SynapClient {
   getContextForPrompt(input: GetContextForPromptInput): Promise<ContextForPromptResult>;
   deleteMemory(input: DeleteMemoryInput): Promise<DeleteMemoryResult>;
   shutdown(): Promise<void>;
+
+  // Python-parallel namespaced API — see the interfaces above. Installed at
+  // construction; mirrors sdk.fetch / sdk.conversation.* / sdk.memories.* /
+  // sdk.{user,customer,client}.context.fetch from the Python SDK.
+  fetch(input?: SynapNamespacedFetchInput): Promise<any>;
+  readonly conversation: SynapConversationApi;
+  readonly memories: SynapMemoriesApi;
+  readonly user: SynapScopeContextApi;
+  readonly customer: SynapScopeContextApi;
+  readonly client: SynapScopeContextApi;
 }
 
 export interface SetupPythonRuntimeOptions {

--- a/packages/sdks/maximem-synap/maximem_synap/_version.py
+++ b/packages/sdks/maximem-synap/maximem_synap/_version.py
@@ -1,3 +1,3 @@
 """Version information for MaximemSynap SDK."""
 
-__version__ = "0.2.5"
+__version__ = "0.2.6"

--- a/packages/sdks/maximem-synap/pyproject.toml
+++ b/packages/sdks/maximem-synap/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "maximem-synap"
-version = "0.2.6"
+dynamic = ["version"]
 description = "Python SDK for MaximemSynap context management system"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -17,9 +17,6 @@ classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
 ]
@@ -57,23 +54,26 @@ Homepage = "https://github.com/maximem-synap/sdk-python"
 Documentation = "https://docs.synap.example.com"
 Repository = "https://github.com/maximem-synap/sdk-python"
 
+[tool.setuptools.dynamic]
+version = {attr = "maximem_synap._version.__version__"}
+
 [tool.setuptools.packages.find]
 where = ["."]
 include = ["maximem_synap*"]
 
 [tool.black]
 line-length = 88
-target-version = ['py38']
+target-version = ['py311']
 
 [tool.mypy]
-python_version = "3.8"
+python_version = "3.11"
 warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = false
 
 [tool.ruff]
 line-length = 88
-target-version = "py38"
+target-version = "py311"
 
 [tool.pytest.ini_options]
 testpaths = ["../../tests/sdk"]


### PR DESCRIPTION
## What & why

Two SDK fixes (also ported to the master monorepo so the two stay in sync).

### #1 — JS SDK shape
The TypeScript framework integrations consume an SDK via a duck-typed `SynapSdkLike` interface that expects a **namespaced, snake_case** shape (`sdk.conversation.record_message`, `sdk.memories.create`, `sdk.{user,customer,client}.context.fetch`, `sdk.fetch`). The JS client only exposed flat camelCase methods, so the real client was **never assignable** to that interface — and no test caught it (integrations mock `SynapSdkLike`).

Adds the namespaced surface **additively** (flat methods untouched):
- **bridge:** `record_message` + `create_memory` handlers
- **client:** `#installNamespacedApi()` facade (accepts snake_case *and* camelCase)
- **types:** namespaced interfaces + client members; id inputs accept `string | null` so `SynapClient` satisfies the integrations' `SynapSdkLike`

### #2 — version drift
`_version.py` had regressed to `0.2.5` while `pyproject.toml` declared `0.2.6` (a stale staging sync reverted the `0.2.6` release bump). Restores `_version.py` to `0.2.6` and single-sources it via setuptools dynamic version so the runtime constant and package metadata can't drift again.

## Verification
- `npm test` → **111/111 pass**
- Facade routing smoke test → **26/26 pass**
- Strict `tsc` assignability of `SynapClient` against **both** integration `SynapSdkLike` interfaces → **exit 0** (caught & fixed a real `| null` gap)
- `pyproject` build resolves to `0.2.6`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
