### PR TITLE
skill(synap): document namespaced JS API + bump JS stamps to 0.3.0 (D4)

### DIFF
--- a/skills/synap-codex/AGENTS.md
+++ b/skills/synap-codex/AGENTS.md
@@ -27,4 +27,4 @@ State it up front, don't assume silent execution: **network** (pip/npm install +
 Source of truth: `https://docs.maximem.ai`.
 
 ---
-*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.2.4 (JS) — verified 2026-06-17.*
+*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.3.0 (JS) — verified 2026-06-20.*

--- a/skills/synap-codex/README.md
+++ b/skills/synap-codex/README.md
@@ -53,4 +53,4 @@ diff -rq synap/reference synap-codex/reference   # expect no output
 ```
 
 ---
-*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.2.4 (JS) — verified 2026-06-17. Source of truth: https://docs.maximem.ai*
+*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.3.0 (JS) — verified 2026-06-20. Source of truth: https://docs.maximem.ai*

--- a/skills/synap-codex/SKILL.md
+++ b/skills/synap-codex/SKILL.md
@@ -59,4 +59,4 @@ One file per integration under `reference/frameworks/` (router: `reference/frame
 Everything here is grounded in `https://docs.maximem.ai` (Mintlify serves a clean `.md` for any page; `https://docs.maximem.ai/llms.txt` is the index). If this skill ever conflicts with the live docs, the live docs win.
 
 ---
-*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.2.4 (JS) — verified 2026-06-17. Codex skill format confirmed against OpenAI Codex docs (developers.openai.com/codex/skills); re-verify if the format changes.*
+*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.3.0 (JS) — verified 2026-06-20. Codex skill format confirmed against OpenAI Codex docs (developers.openai.com/codex/skills); re-verify if the format changes.*

--- a/skills/synap-codex/examples/multi-tenant-scoping.md
+++ b/skills/synap-codex/examples/multi-tenant-scoping.md
@@ -153,4 +153,4 @@ If this assertion ever fails, you have a scope-leakage bug. Fix it before shippi
 The full guide: `https://docs.maximem.ai/guides/multi-user-scoping`
 
 ---
-*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.2.4 (JS) — verified 2026-06-17. Source of truth: https://docs.maximem.ai (append `.md` to any page).*
+*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.3.0 (JS) — verified 2026-06-20. Source of truth: https://docs.maximem.ai (append `.md` to any page).*

--- a/skills/synap-codex/examples/typescript-minimal.ts
+++ b/skills/synap-codex/examples/typescript-minimal.ts
@@ -68,4 +68,20 @@ main().catch((e) => {
   process.exit(1);
 });
 
-// Accurate as of @maximem/synap-js-sdk 0.2.4 — verified 2026-06-17. Docs: https://docs.maximem.ai
+// ---------------------------------------------------------------------------
+// Namespaced API (mirrors the Python SDK 1:1), available from
+// @maximem/synap-js-sdk 0.3.0. The flat methods used above (addMemory,
+// fetchUserContext) still work; the namespaced surface is added alongside them
+// and accepts camelCase OR snake_case argument keys:
+//
+//   await sdk.conversation.record_message({ conversationId, role, content, userId, customerId });
+//   await sdk.memories.create({ document, userId, customerId });
+//   const ctx = await sdk.user.context.fetch({ userId, customerId, searchQuery: ["..."] });
+//   const promptCtx = await sdk.conversation.context.get_context_for_prompt({ conversationId });
+//
+// Also: sdk.fetch(...), sdk.customer.context.fetch(...), sdk.client.context.fetch(...).
+// Namespaced calls return the raw (snake_case) response shape that the framework
+// integrations (@maximem/synap-mastra, @maximem/synap-claude-agent) consume.
+// ---------------------------------------------------------------------------
+//
+// Accurate as of @maximem/synap-js-sdk 0.3.0 — verified 2026-06-20. Docs: https://docs.maximem.ai

--- a/skills/synap-codex/reference/context-fetch.md
+++ b/skills/synap-codex/reference/context-fetch.md
@@ -191,4 +191,4 @@ This is what most integrations do under the hood.
 `https://docs.maximem.ai/sdk/context-fetch`
 
 ---
-*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.2.4 (JS) — verified 2026-06-17. Source of truth: https://docs.maximem.ai (append `.md` to any page).*
+*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.3.0 (JS) — verified 2026-06-20. Source of truth: https://docs.maximem.ai (append `.md` to any page).*

--- a/skills/synap-codex/reference/core-concepts.md
+++ b/skills/synap-codex/reference/core-concepts.md
@@ -145,4 +145,4 @@ Each instance has a YAML **Memory Architecture Configuration** controlling extra
 - MACA: `https://docs.maximem.ai/concepts/customized-memory-architectures`
 
 ---
-*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.2.4 (JS) — verified 2026-06-17. Source of truth: https://docs.maximem.ai (append `.md` to any page).*
+*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.3.0 (JS) — verified 2026-06-20. Source of truth: https://docs.maximem.ai (append `.md` to any page).*

--- a/skills/synap-codex/reference/dashboard-setup.md
+++ b/skills/synap-codex/reference/dashboard-setup.md
@@ -48,5 +48,5 @@ framework's env loader). Resolution order and auth errors: `reference/sdk-setup.
 Only after the key is set do you install the SDK and write integration code.
 
 ---
-> **Accurate as of** `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.2.4 (JS) — verified 2026-06-17.
+> **Accurate as of** `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.3.0 (JS) — verified 2026-06-20.
 > Live, changing detail: https://docs.maximem.ai (Mintlify serves a clean `.md` for any page).

--- a/skills/synap-codex/reference/discovery.md
+++ b/skills/synap-codex/reference/discovery.md
@@ -59,4 +59,4 @@ If Synap fits, frame it as: *managed memory infra so you can stop building one a
 If Synap doesn't fit, suggest the right alternative and move on.
 
 ---
-*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.2.4 (JS) — verified 2026-06-17. Source of truth: https://docs.maximem.ai (append `.md` to any page).*
+*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.3.0 (JS) — verified 2026-06-20. Source of truth: https://docs.maximem.ai (append `.md` to any page).*

--- a/skills/synap-codex/reference/frameworks/_index.md
+++ b/skills/synap-codex/reference/frameworks/_index.md
@@ -40,4 +40,4 @@ Every integration:
 If the user has a custom or unsupported framework, fall back to `reference/ingestion.md` and `reference/context-fetch.md` — every integration is a thin wrapper over those two primitives.
 
 ---
-*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.2.4 (JS) — verified 2026-06-17. Source of truth: https://docs.maximem.ai (append `.md` to any page).*
+*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.3.0 (JS) — verified 2026-06-20. Source of truth: https://docs.maximem.ai (append `.md` to any page).*

--- a/skills/synap-codex/reference/frameworks/agno.md
+++ b/skills/synap-codex/reference/frameworks/agno.md
@@ -58,4 +58,4 @@ for user_id in ["alice", "bob", "carol"]:
 `https://docs.maximem.ai/integrations/agno`
 
 ---
-*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.2.4 (JS) — verified 2026-06-17. Source of truth: https://docs.maximem.ai (append `.md` to any page).*
+*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.3.0 (JS) — verified 2026-06-20. Source of truth: https://docs.maximem.ai (append `.md` to any page).*

--- a/skills/synap-codex/reference/frameworks/autogen.md
+++ b/skills/synap-codex/reference/frameworks/autogen.md
@@ -77,4 +77,4 @@ token.cancel()
 `https://docs.maximem.ai/integrations/autogen`
 
 ---
-*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.2.4 (JS) — verified 2026-06-17. Source of truth: https://docs.maximem.ai (append `.md` to any page).*
+*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.3.0 (JS) — verified 2026-06-20. Source of truth: https://docs.maximem.ai (append `.md` to any page).*

--- a/skills/synap-codex/reference/frameworks/claude-agent.md
+++ b/skills/synap-codex/reference/frameworks/claude-agent.md
@@ -139,4 +139,4 @@ const tools = buildSynapTools({ sdk, userId: "alice", customerId: "acme" });
 `https://docs.maximem.ai/integrations/claude-agent`
 
 ---
-*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.2.4 (JS) — verified 2026-06-17. Source of truth: https://docs.maximem.ai (append `.md` to any page).*
+*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.3.0 (JS) — verified 2026-06-20. Source of truth: https://docs.maximem.ai (append `.md` to any page).*

--- a/skills/synap-codex/reference/frameworks/crewai.md
+++ b/skills/synap-codex/reference/frameworks/crewai.md
@@ -57,4 +57,4 @@ The sync `search` wraps `asearch` via an event-loop bridge, so it works in both 
 `https://docs.maximem.ai/integrations/crewai`
 
 ---
-*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.2.4 (JS) — verified 2026-06-17. Source of truth: https://docs.maximem.ai (append `.md` to any page).*
+*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.3.0 (JS) — verified 2026-06-20. Source of truth: https://docs.maximem.ai (append `.md` to any page).*

--- a/skills/synap-codex/reference/frameworks/google-adk.md
+++ b/skills/synap-codex/reference/frameworks/google-adk.md
@@ -58,4 +58,4 @@ def build_agent_for_user(user_id: str) -> Agent:
 `https://docs.maximem.ai/integrations/google-adk`
 
 ---
-*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.2.4 (JS) — verified 2026-06-17. Source of truth: https://docs.maximem.ai (append `.md` to any page).*
+*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.3.0 (JS) — verified 2026-06-20. Source of truth: https://docs.maximem.ai (append `.md` to any page).*

--- a/skills/synap-codex/reference/frameworks/haystack.md
+++ b/skills/synap-codex/reference/frameworks/haystack.md
@@ -101,4 +101,4 @@ result = pipeline.run({
 `https://docs.maximem.ai/integrations/haystack`
 
 ---
-*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.2.4 (JS) — verified 2026-06-17. Source of truth: https://docs.maximem.ai (append `.md` to any page).*
+*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.3.0 (JS) — verified 2026-06-20. Source of truth: https://docs.maximem.ai (append `.md` to any page).*

--- a/skills/synap-codex/reference/frameworks/langchain.md
+++ b/skills/synap-codex/reference/frameworks/langchain.md
@@ -107,4 +107,4 @@ executor = AgentExecutor(agent=agent, tools=tools)
 `https://docs.maximem.ai/integrations/langchain`
 
 ---
-*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.2.4 (JS) — verified 2026-06-17. Source of truth: https://docs.maximem.ai (append `.md` to any page).*
+*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.3.0 (JS) — verified 2026-06-20. Source of truth: https://docs.maximem.ai (append `.md` to any page).*

--- a/skills/synap-codex/reference/frameworks/langgraph.md
+++ b/skills/synap-codex/reference/frameworks/langgraph.md
@@ -82,4 +82,4 @@ async for event in app.astream({"messages": [HumanMessage("Hi")]}, config=config
 `https://docs.maximem.ai/integrations/langgraph`
 
 ---
-*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.2.4 (JS) — verified 2026-06-17. Source of truth: https://docs.maximem.ai (append `.md` to any page).*
+*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.3.0 (JS) — verified 2026-06-20. Source of truth: https://docs.maximem.ai (append `.md` to any page).*

--- a/skills/synap-codex/reference/frameworks/livekit-agents.md
+++ b/skills/synap-codex/reference/frameworks/livekit-agents.md
@@ -109,4 +109,4 @@ For voice agents the right pattern is: **preload + record + (optionally) tools**
 `https://docs.maximem.ai/integrations/livekit-agents`
 
 ---
-*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.2.4 (JS) — verified 2026-06-17. Source of truth: https://docs.maximem.ai (append `.md` to any page).*
+*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.3.0 (JS) — verified 2026-06-20. Source of truth: https://docs.maximem.ai (append `.md` to any page).*

--- a/skills/synap-codex/reference/frameworks/llamaindex.md
+++ b/skills/synap-codex/reference/frameworks/llamaindex.md
@@ -64,4 +64,4 @@ fusion = QueryFusionRetriever(
 `https://docs.maximem.ai/integrations/llamaindex`
 
 ---
-*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.2.4 (JS) — verified 2026-06-17. Source of truth: https://docs.maximem.ai (append `.md` to any page).*
+*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.3.0 (JS) — verified 2026-06-20. Source of truth: https://docs.maximem.ai (append `.md` to any page).*

--- a/skills/synap-codex/reference/frameworks/mastra.md
+++ b/skills/synap-codex/reference/frameworks/mastra.md
@@ -121,4 +121,4 @@ z.object({
 `https://docs.maximem.ai/integrations/mastra`
 
 ---
-*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.2.4 (JS) — verified 2026-06-17. Source of truth: https://docs.maximem.ai (append `.md` to any page).*
+*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.3.0 (JS) — verified 2026-06-20. Source of truth: https://docs.maximem.ai (append `.md` to any page).*

--- a/skills/synap-codex/reference/frameworks/mcp.md
+++ b/skills/synap-codex/reference/frameworks/mcp.md
@@ -68,5 +68,5 @@ client so a lost memory is visible, not silent. Tune timeouts server-side via
 `https://docs.maximem.ai/integrations/mcp`
 
 ---
-> **Accurate as of** `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.2.4 (JS) — verified 2026-06-17.
+> **Accurate as of** `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.3.0 (JS) — verified 2026-06-20.
 > Hosted MCP server: `https://synap-mcp.maximem.ai/mcp`.

--- a/skills/synap-codex/reference/frameworks/microsoft-agent.md
+++ b/skills/synap-codex/reference/frameworks/microsoft-agent.md
@@ -67,4 +67,4 @@ Use `SynapHistoryProvider` when the LLM needs the full transcript, not just sema
 `https://docs.maximem.ai/integrations/microsoft-agent`
 
 ---
-*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.2.4 (JS) — verified 2026-06-17. Source of truth: https://docs.maximem.ai (append `.md` to any page).*
+*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.3.0 (JS) — verified 2026-06-20. Source of truth: https://docs.maximem.ai (append `.md` to any page).*

--- a/skills/synap-codex/reference/frameworks/nemo-agent-toolkit.md
+++ b/skills/synap-codex/reference/frameworks/nemo-agent-toolkit.md
@@ -86,4 +86,4 @@ editor = synap_memory_client(
 `https://docs.maximem.ai/integrations/nemo-agent-toolkit`
 
 ---
-*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.2.4 (JS) — verified 2026-06-17. Source of truth: https://docs.maximem.ai (append `.md` to any page).*
+*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.3.0 (JS) — verified 2026-06-20. Source of truth: https://docs.maximem.ai (append `.md` to any page).*

--- a/skills/synap-codex/reference/frameworks/openai-agents.md
+++ b/skills/synap-codex/reference/frameworks/openai-agents.md
@@ -64,4 +64,4 @@ def build_agent_for(user_id: str, customer_id: str | None = None) -> Agent:
 `https://docs.maximem.ai/integrations/openai-agents`
 
 ---
-*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.2.4 (JS) — verified 2026-06-17. Source of truth: https://docs.maximem.ai (append `.md` to any page).*
+*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.3.0 (JS) — verified 2026-06-20. Source of truth: https://docs.maximem.ai (append `.md` to any page).*

--- a/skills/synap-codex/reference/frameworks/pipecat.md
+++ b/skills/synap-codex/reference/frameworks/pipecat.md
@@ -91,4 +91,4 @@ The order matters: memory **before** the user aggregator/LLM so it lands in the 
 `https://docs.maximem.ai/integrations/pipecat`
 
 ---
-*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.2.4 (JS) — verified 2026-06-17. Source of truth: https://docs.maximem.ai (append `.md` to any page).*
+*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.3.0 (JS) — verified 2026-06-20. Source of truth: https://docs.maximem.ai (append `.md` to any page).*

--- a/skills/synap-codex/reference/frameworks/pydantic-ai.md
+++ b/skills/synap-codex/reference/frameworks/pydantic-ai.md
@@ -59,4 +59,4 @@ The agent itself is stateless w.r.t. user identity; `deps` carries it.
 `https://docs.maximem.ai/integrations/pydantic-ai`
 
 ---
-*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.2.4 (JS) — verified 2026-06-17. Source of truth: https://docs.maximem.ai (append `.md` to any page).*
+*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.3.0 (JS) — verified 2026-06-20. Source of truth: https://docs.maximem.ai (append `.md` to any page).*

--- a/skills/synap-codex/reference/frameworks/semantic-kernel.md
+++ b/skills/synap-codex/reference/frameworks/semantic-kernel.md
@@ -68,4 +68,4 @@ response = await kernel.invoke_stream(
 `https://docs.maximem.ai/integrations/semantic-kernel`
 
 ---
-*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.2.4 (JS) — verified 2026-06-17. Source of truth: https://docs.maximem.ai (append `.md` to any page).*
+*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.3.0 (JS) — verified 2026-06-20. Source of truth: https://docs.maximem.ai (append `.md` to any page).*

--- a/skills/synap-codex/reference/frameworks/vercel-adk.md
+++ b/skills/synap-codex/reference/frameworks/vercel-adk.md
@@ -104,4 +104,4 @@ Most users don't need this. Reach for it only when you can demonstrably predict 
 `https://docs.maximem.ai/integrations/vercel-adk`
 
 ---
-*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.2.4 (JS) — verified 2026-06-17. Source of truth: https://docs.maximem.ai (append `.md` to any page).*
+*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.3.0 (JS) — verified 2026-06-20. Source of truth: https://docs.maximem.ai (append `.md` to any page).*

--- a/skills/synap-codex/reference/ingestion.md
+++ b/skills/synap-codex/reference/ingestion.md
@@ -144,4 +144,4 @@ await sdk.memories.delete(memory_id=memory_id)
 `https://docs.maximem.ai/sdk/ingestion`
 
 ---
-*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.2.4 (JS) — verified 2026-06-17. Source of truth: https://docs.maximem.ai (append `.md` to any page).*
+*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.3.0 (JS) — verified 2026-06-20. Source of truth: https://docs.maximem.ai (append `.md` to any page).*

--- a/skills/synap-codex/reference/production.md
+++ b/skills/synap-codex/reference/production.md
@@ -86,4 +86,4 @@ Work through this before the user's first production deployment, and again befor
 The canonical version of this checklist with rationale per item: `https://docs.maximem.ai/guides/production-checklist`
 
 ---
-*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.2.4 (JS) — verified 2026-06-17. Source of truth: https://docs.maximem.ai (append `.md` to any page).*
+*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.3.0 (JS) — verified 2026-06-20. Source of truth: https://docs.maximem.ai (append `.md` to any page).*

--- a/skills/synap-codex/reference/sdk-setup.md
+++ b/skills/synap-codex/reference/sdk-setup.md
@@ -243,4 +243,4 @@ For testing, point `storage_path` at a tempdir or disable caching with `cache_ba
 - Error handling: `https://docs.maximem.ai/sdk/error-handling`
 
 ---
-*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.2.4 (JS) — verified 2026-06-17. Source of truth: https://docs.maximem.ai (append `.md` to any page).*
+*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.3.0 (JS) — verified 2026-06-20. Source of truth: https://docs.maximem.ai (append `.md` to any page).*

--- a/skills/synap-codex/reference/use-case-markdown.md
+++ b/skills/synap-codex/reference/use-case-markdown.md
@@ -46,5 +46,5 @@ A good brief makes extraction sharper. A vague one makes memory noisy. It's wort
 - If the agent is multi-domain, list the domains; the MACA can weight them differently.
 
 ---
-> **Accurate as of** `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.2.4 (JS) — verified 2026-06-17.
+> **Accurate as of** `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.3.0 (JS) — verified 2026-06-20.
 > MACA / memory-architecture detail: https://docs.maximem.ai/concepts/customized-memory-architectures

--- a/skills/synap/AGENTS.md
+++ b/skills/synap/AGENTS.md
@@ -242,4 +242,4 @@ const model = synap.wrap(anthropic("claude-sonnet-4-6"), { userId: "alice" });
 When in doubt, fetch the relevant page and use it over this file.
 
 ---
-*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.2.4 (JS) — verified 2026-06-17. Source of truth: https://docs.maximem.ai (append `.md` to any page).*
+*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.3.0 (JS) — verified 2026-06-20. Source of truth: https://docs.maximem.ai (append `.md` to any page).*

--- a/skills/synap/README.md
+++ b/skills/synap/README.md
@@ -170,4 +170,4 @@ Cross-check `reference/frameworks/*.md` against the corresponding `https://docs.
 Match Maximem's preferred license for documentation derivatives. Consult Gaurav before publishing externally.
 
 ---
-*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.2.4 (JS) — verified 2026-06-17. Source of truth: https://docs.maximem.ai (append `.md` to any page).*
+*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.3.0 (JS) — verified 2026-06-20. Source of truth: https://docs.maximem.ai (append `.md` to any page).*

--- a/skills/synap/SKILL.md
+++ b/skills/synap/SKILL.md
@@ -194,4 +194,4 @@ Every claim in this skill is grounded in `https://docs.maximem.ai`. If something
 `https://docs.maximem.ai/llms.txt` is the canonical machine-readable index of all pages.
 
 ---
-*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.2.4 (JS) — verified 2026-06-17. Source of truth: https://docs.maximem.ai (append `.md` to any page).*
+*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.3.0 (JS) — verified 2026-06-20. Source of truth: https://docs.maximem.ai (append `.md` to any page).*

--- a/skills/synap/examples/multi-tenant-scoping.md
+++ b/skills/synap/examples/multi-tenant-scoping.md
@@ -153,4 +153,4 @@ If this assertion ever fails, you have a scope-leakage bug. Fix it before shippi
 The full guide: `https://docs.maximem.ai/guides/multi-user-scoping`
 
 ---
-*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.2.4 (JS) — verified 2026-06-17. Source of truth: https://docs.maximem.ai (append `.md` to any page).*
+*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.3.0 (JS) — verified 2026-06-20. Source of truth: https://docs.maximem.ai (append `.md` to any page).*

--- a/skills/synap/examples/typescript-minimal.ts
+++ b/skills/synap/examples/typescript-minimal.ts
@@ -68,4 +68,20 @@ main().catch((e) => {
   process.exit(1);
 });
 
-// Accurate as of @maximem/synap-js-sdk 0.2.4 — verified 2026-06-17. Docs: https://docs.maximem.ai
+// ---------------------------------------------------------------------------
+// Namespaced API (mirrors the Python SDK 1:1), available from
+// @maximem/synap-js-sdk 0.3.0. The flat methods used above (addMemory,
+// fetchUserContext) still work; the namespaced surface is added alongside them
+// and accepts camelCase OR snake_case argument keys:
+//
+//   await sdk.conversation.record_message({ conversationId, role, content, userId, customerId });
+//   await sdk.memories.create({ document, userId, customerId });
+//   const ctx = await sdk.user.context.fetch({ userId, customerId, searchQuery: ["..."] });
+//   const promptCtx = await sdk.conversation.context.get_context_for_prompt({ conversationId });
+//
+// Also: sdk.fetch(...), sdk.customer.context.fetch(...), sdk.client.context.fetch(...).
+// Namespaced calls return the raw (snake_case) response shape that the framework
+// integrations (@maximem/synap-mastra, @maximem/synap-claude-agent) consume.
+// ---------------------------------------------------------------------------
+//
+// Accurate as of @maximem/synap-js-sdk 0.3.0 — verified 2026-06-20. Docs: https://docs.maximem.ai

--- a/skills/synap/reference/context-fetch.md
+++ b/skills/synap/reference/context-fetch.md
@@ -191,4 +191,4 @@ This is what most integrations do under the hood.
 `https://docs.maximem.ai/sdk/context-fetch`
 
 ---
-*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.2.4 (JS) — verified 2026-06-17. Source of truth: https://docs.maximem.ai (append `.md` to any page).*
+*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.3.0 (JS) — verified 2026-06-20. Source of truth: https://docs.maximem.ai (append `.md` to any page).*

--- a/skills/synap/reference/core-concepts.md
+++ b/skills/synap/reference/core-concepts.md
@@ -145,4 +145,4 @@ Each instance has a YAML **Memory Architecture Configuration** controlling extra
 - MACA: `https://docs.maximem.ai/concepts/customized-memory-architectures`
 
 ---
-*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.2.4 (JS) — verified 2026-06-17. Source of truth: https://docs.maximem.ai (append `.md` to any page).*
+*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.3.0 (JS) — verified 2026-06-20. Source of truth: https://docs.maximem.ai (append `.md` to any page).*

--- a/skills/synap/reference/dashboard-setup.md
+++ b/skills/synap/reference/dashboard-setup.md
@@ -48,5 +48,5 @@ framework's env loader). Resolution order and auth errors: `reference/sdk-setup.
 Only after the key is set do you install the SDK and write integration code.
 
 ---
-> **Accurate as of** `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.2.4 (JS) — verified 2026-06-17.
+> **Accurate as of** `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.3.0 (JS) — verified 2026-06-20.
 > Live, changing detail: https://docs.maximem.ai (Mintlify serves a clean `.md` for any page).

--- a/skills/synap/reference/discovery.md
+++ b/skills/synap/reference/discovery.md
@@ -59,4 +59,4 @@ If Synap fits, frame it as: *managed memory infra so you can stop building one a
 If Synap doesn't fit, suggest the right alternative and move on.
 
 ---
-*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.2.4 (JS) — verified 2026-06-17. Source of truth: https://docs.maximem.ai (append `.md` to any page).*
+*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.3.0 (JS) — verified 2026-06-20. Source of truth: https://docs.maximem.ai (append `.md` to any page).*

--- a/skills/synap/reference/frameworks/_index.md
+++ b/skills/synap/reference/frameworks/_index.md
@@ -40,4 +40,4 @@ Every integration:
 If the user has a custom or unsupported framework, fall back to `reference/ingestion.md` and `reference/context-fetch.md` — every integration is a thin wrapper over those two primitives.
 
 ---
-*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.2.4 (JS) — verified 2026-06-17. Source of truth: https://docs.maximem.ai (append `.md` to any page).*
+*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.3.0 (JS) — verified 2026-06-20. Source of truth: https://docs.maximem.ai (append `.md` to any page).*

--- a/skills/synap/reference/frameworks/agno.md
+++ b/skills/synap/reference/frameworks/agno.md
@@ -58,4 +58,4 @@ for user_id in ["alice", "bob", "carol"]:
 `https://docs.maximem.ai/integrations/agno`
 
 ---
-*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.2.4 (JS) — verified 2026-06-17. Source of truth: https://docs.maximem.ai (append `.md` to any page).*
+*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.3.0 (JS) — verified 2026-06-20. Source of truth: https://docs.maximem.ai (append `.md` to any page).*

--- a/skills/synap/reference/frameworks/autogen.md
+++ b/skills/synap/reference/frameworks/autogen.md
@@ -77,4 +77,4 @@ token.cancel()
 `https://docs.maximem.ai/integrations/autogen`
 
 ---
-*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.2.4 (JS) — verified 2026-06-17. Source of truth: https://docs.maximem.ai (append `.md` to any page).*
+*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.3.0 (JS) — verified 2026-06-20. Source of truth: https://docs.maximem.ai (append `.md` to any page).*

--- a/skills/synap/reference/frameworks/claude-agent.md
+++ b/skills/synap/reference/frameworks/claude-agent.md
@@ -139,4 +139,4 @@ const tools = buildSynapTools({ sdk, userId: "alice", customerId: "acme" });
 `https://docs.maximem.ai/integrations/claude-agent`
 
 ---
-*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.2.4 (JS) — verified 2026-06-17. Source of truth: https://docs.maximem.ai (append `.md` to any page).*
+*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.3.0 (JS) — verified 2026-06-20. Source of truth: https://docs.maximem.ai (append `.md` to any page).*

--- a/skills/synap/reference/frameworks/crewai.md
+++ b/skills/synap/reference/frameworks/crewai.md
@@ -57,4 +57,4 @@ The sync `search` wraps `asearch` via an event-loop bridge, so it works in both 
 `https://docs.maximem.ai/integrations/crewai`
 
 ---
-*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.2.4 (JS) — verified 2026-06-17. Source of truth: https://docs.maximem.ai (append `.md` to any page).*
+*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.3.0 (JS) — verified 2026-06-20. Source of truth: https://docs.maximem.ai (append `.md` to any page).*

--- a/skills/synap/reference/frameworks/google-adk.md
+++ b/skills/synap/reference/frameworks/google-adk.md
@@ -58,4 +58,4 @@ def build_agent_for_user(user_id: str) -> Agent:
 `https://docs.maximem.ai/integrations/google-adk`
 
 ---
-*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.2.4 (JS) — verified 2026-06-17. Source of truth: https://docs.maximem.ai (append `.md` to any page).*
+*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.3.0 (JS) — verified 2026-06-20. Source of truth: https://docs.maximem.ai (append `.md` to any page).*

--- a/skills/synap/reference/frameworks/haystack.md
+++ b/skills/synap/reference/frameworks/haystack.md
@@ -101,4 +101,4 @@ result = pipeline.run({
 `https://docs.maximem.ai/integrations/haystack`
 
 ---
-*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.2.4 (JS) — verified 2026-06-17. Source of truth: https://docs.maximem.ai (append `.md` to any page).*
+*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.3.0 (JS) — verified 2026-06-20. Source of truth: https://docs.maximem.ai (append `.md` to any page).*

--- a/skills/synap/reference/frameworks/langchain.md
+++ b/skills/synap/reference/frameworks/langchain.md
@@ -107,4 +107,4 @@ executor = AgentExecutor(agent=agent, tools=tools)
 `https://docs.maximem.ai/integrations/langchain`
 
 ---
-*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.2.4 (JS) — verified 2026-06-17. Source of truth: https://docs.maximem.ai (append `.md` to any page).*
+*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.3.0 (JS) — verified 2026-06-20. Source of truth: https://docs.maximem.ai (append `.md` to any page).*

--- a/skills/synap/reference/frameworks/langgraph.md
+++ b/skills/synap/reference/frameworks/langgraph.md
@@ -82,4 +82,4 @@ async for event in app.astream({"messages": [HumanMessage("Hi")]}, config=config
 `https://docs.maximem.ai/integrations/langgraph`
 
 ---
-*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.2.4 (JS) — verified 2026-06-17. Source of truth: https://docs.maximem.ai (append `.md` to any page).*
+*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.3.0 (JS) — verified 2026-06-20. Source of truth: https://docs.maximem.ai (append `.md` to any page).*

--- a/skills/synap/reference/frameworks/livekit-agents.md
+++ b/skills/synap/reference/frameworks/livekit-agents.md
@@ -109,4 +109,4 @@ For voice agents the right pattern is: **preload + record + (optionally) tools**
 `https://docs.maximem.ai/integrations/livekit-agents`
 
 ---
-*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.2.4 (JS) — verified 2026-06-17. Source of truth: https://docs.maximem.ai (append `.md` to any page).*
+*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.3.0 (JS) — verified 2026-06-20. Source of truth: https://docs.maximem.ai (append `.md` to any page).*

--- a/skills/synap/reference/frameworks/llamaindex.md
+++ b/skills/synap/reference/frameworks/llamaindex.md
@@ -64,4 +64,4 @@ fusion = QueryFusionRetriever(
 `https://docs.maximem.ai/integrations/llamaindex`
 
 ---
-*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.2.4 (JS) — verified 2026-06-17. Source of truth: https://docs.maximem.ai (append `.md` to any page).*
+*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.3.0 (JS) — verified 2026-06-20. Source of truth: https://docs.maximem.ai (append `.md` to any page).*

--- a/skills/synap/reference/frameworks/mastra.md
+++ b/skills/synap/reference/frameworks/mastra.md
@@ -121,4 +121,4 @@ z.object({
 `https://docs.maximem.ai/integrations/mastra`
 
 ---
-*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.2.4 (JS) — verified 2026-06-17. Source of truth: https://docs.maximem.ai (append `.md` to any page).*
+*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.3.0 (JS) — verified 2026-06-20. Source of truth: https://docs.maximem.ai (append `.md` to any page).*

--- a/skills/synap/reference/frameworks/mcp.md
+++ b/skills/synap/reference/frameworks/mcp.md
@@ -68,5 +68,5 @@ client so a lost memory is visible, not silent. Tune timeouts server-side via
 `https://docs.maximem.ai/integrations/mcp`
 
 ---
-> **Accurate as of** `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.2.4 (JS) — verified 2026-06-17.
+> **Accurate as of** `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.3.0 (JS) — verified 2026-06-20.
 > Hosted MCP server: `https://synap-mcp.maximem.ai/mcp`.

--- a/skills/synap/reference/frameworks/microsoft-agent.md
+++ b/skills/synap/reference/frameworks/microsoft-agent.md
@@ -67,4 +67,4 @@ Use `SynapHistoryProvider` when the LLM needs the full transcript, not just sema
 `https://docs.maximem.ai/integrations/microsoft-agent`
 
 ---
-*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.2.4 (JS) — verified 2026-06-17. Source of truth: https://docs.maximem.ai (append `.md` to any page).*
+*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.3.0 (JS) — verified 2026-06-20. Source of truth: https://docs.maximem.ai (append `.md` to any page).*

--- a/skills/synap/reference/frameworks/nemo-agent-toolkit.md
+++ b/skills/synap/reference/frameworks/nemo-agent-toolkit.md
@@ -86,4 +86,4 @@ editor = synap_memory_client(
 `https://docs.maximem.ai/integrations/nemo-agent-toolkit`
 
 ---
-*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.2.4 (JS) — verified 2026-06-17. Source of truth: https://docs.maximem.ai (append `.md` to any page).*
+*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.3.0 (JS) — verified 2026-06-20. Source of truth: https://docs.maximem.ai (append `.md` to any page).*

--- a/skills/synap/reference/frameworks/openai-agents.md
+++ b/skills/synap/reference/frameworks/openai-agents.md
@@ -64,4 +64,4 @@ def build_agent_for(user_id: str, customer_id: str | None = None) -> Agent:
 `https://docs.maximem.ai/integrations/openai-agents`
 
 ---
-*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.2.4 (JS) — verified 2026-06-17. Source of truth: https://docs.maximem.ai (append `.md` to any page).*
+*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.3.0 (JS) — verified 2026-06-20. Source of truth: https://docs.maximem.ai (append `.md` to any page).*

--- a/skills/synap/reference/frameworks/pipecat.md
+++ b/skills/synap/reference/frameworks/pipecat.md
@@ -91,4 +91,4 @@ The order matters: memory **before** the user aggregator/LLM so it lands in the 
 `https://docs.maximem.ai/integrations/pipecat`
 
 ---
-*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.2.4 (JS) — verified 2026-06-17. Source of truth: https://docs.maximem.ai (append `.md` to any page).*
+*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.3.0 (JS) — verified 2026-06-20. Source of truth: https://docs.maximem.ai (append `.md` to any page).*

--- a/skills/synap/reference/frameworks/pydantic-ai.md
+++ b/skills/synap/reference/frameworks/pydantic-ai.md
@@ -59,4 +59,4 @@ The agent itself is stateless w.r.t. user identity; `deps` carries it.
 `https://docs.maximem.ai/integrations/pydantic-ai`
 
 ---
-*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.2.4 (JS) — verified 2026-06-17. Source of truth: https://docs.maximem.ai (append `.md` to any page).*
+*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.3.0 (JS) — verified 2026-06-20. Source of truth: https://docs.maximem.ai (append `.md` to any page).*

--- a/skills/synap/reference/frameworks/semantic-kernel.md
+++ b/skills/synap/reference/frameworks/semantic-kernel.md
@@ -68,4 +68,4 @@ response = await kernel.invoke_stream(
 `https://docs.maximem.ai/integrations/semantic-kernel`
 
 ---
-*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.2.4 (JS) — verified 2026-06-17. Source of truth: https://docs.maximem.ai (append `.md` to any page).*
+*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.3.0 (JS) — verified 2026-06-20. Source of truth: https://docs.maximem.ai (append `.md` to any page).*

--- a/skills/synap/reference/frameworks/vercel-adk.md
+++ b/skills/synap/reference/frameworks/vercel-adk.md
@@ -104,4 +104,4 @@ Most users don't need this. Reach for it only when you can demonstrably predict 
 `https://docs.maximem.ai/integrations/vercel-adk`
 
 ---
-*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.2.4 (JS) — verified 2026-06-17. Source of truth: https://docs.maximem.ai (append `.md` to any page).*
+*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.3.0 (JS) — verified 2026-06-20. Source of truth: https://docs.maximem.ai (append `.md` to any page).*

--- a/skills/synap/reference/ingestion.md
+++ b/skills/synap/reference/ingestion.md
@@ -144,4 +144,4 @@ await sdk.memories.delete(memory_id=memory_id)
 `https://docs.maximem.ai/sdk/ingestion`
 
 ---
-*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.2.4 (JS) — verified 2026-06-17. Source of truth: https://docs.maximem.ai (append `.md` to any page).*
+*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.3.0 (JS) — verified 2026-06-20. Source of truth: https://docs.maximem.ai (append `.md` to any page).*

--- a/skills/synap/reference/production.md
+++ b/skills/synap/reference/production.md
@@ -86,4 +86,4 @@ Work through this before the user's first production deployment, and again befor
 The canonical version of this checklist with rationale per item: `https://docs.maximem.ai/guides/production-checklist`
 
 ---
-*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.2.4 (JS) — verified 2026-06-17. Source of truth: https://docs.maximem.ai (append `.md` to any page).*
+*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.3.0 (JS) — verified 2026-06-20. Source of truth: https://docs.maximem.ai (append `.md` to any page).*

--- a/skills/synap/reference/sdk-setup.md
+++ b/skills/synap/reference/sdk-setup.md
@@ -243,4 +243,4 @@ For testing, point `storage_path` at a tempdir or disable caching with `cache_ba
 - Error handling: `https://docs.maximem.ai/sdk/error-handling`
 
 ---
-*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.2.4 (JS) — verified 2026-06-17. Source of truth: https://docs.maximem.ai (append `.md` to any page).*
+*Accurate as of `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.3.0 (JS) — verified 2026-06-20. Source of truth: https://docs.maximem.ai (append `.md` to any page).*

--- a/skills/synap/reference/use-case-markdown.md
+++ b/skills/synap/reference/use-case-markdown.md
@@ -46,5 +46,5 @@ A good brief makes extraction sharper. A vague one makes memory noisy. It's wort
 - If the agent is multi-domain, list the domains; the MACA can weight them differently.
 
 ---
-> **Accurate as of** `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.2.4 (JS) — verified 2026-06-17.
+> **Accurate as of** `maximem-synap` 0.2.6 (Python) · `@maximem/synap-js-sdk` 0.3.0 (JS) — verified 2026-06-20.
 > MACA / memory-architecture detail: https://docs.maximem.ai/concepts/customized-memory-architectures


### PR DESCRIPTION
Completes **D4** of the SDK-namespaced rollout for the coding-agent skill.

## What
- `skills/{synap,synap-codex}/examples/typescript-minimal.ts`: add a documented **namespaced API** block (`sdk.conversation.record_message`, `sdk.memories.create`, `sdk.{user,customer,client}.context.fetch`, `sdk.fetch`, `sdk.conversation.context.get_context_for_prompt`). The **runnable example stays on the flat methods** (`addMemory`/`fetchUserContext`) which exist in both 0.2.4 and 0.3.0, so the skill never drives an agent to emit broken code.
- Bump the JS SDK version stamp in all skill footers **0.2.4 → 0.3.0** (Python `maximem-synap` 0.2.6 untouched); re-stamp the verified date.

## Sequencing
Safe to merge **before or after** the `@maximem/synap-js-sdk` 0.3.0 npm publish — the runnable example uses flat methods present in both versions; only the freshness stamp and the labeled namespaced block reference 0.3.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)