### PR TITLE
feat(integrations): add DSPy, Smolagents, Camel-AI, Marvin, and Mirascope

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@
 Your AI agents forget everything between conversations. Synap fixes that — with a production-grade memory layer built for applications that serve real users at scale. **#1 on [LongMemEval](https://www.maximem.ai/blog/synap-benchmark-results) (92%) and [LoCoMo](https://www.maximem.ai/blog/synap-benchmark-results) (93.2%)**, sub-15ms anticipatory retrieval, and native integrations with every major AI framework.
 
 <p align="center">
-  <strong>LangChain · LangGraph · LlamaIndex · CrewAI · AutoGen · Haystack · Google ADK · OpenAI Agents · Semantic Kernel · Pydantic AI · Agno · LiveKit · Pipecat · Claude Agent · Mastra · Vercel AI SDK · NeMo Agent Toolkit · Microsoft Agent Framework</strong>
+  <strong>LangChain · LangGraph · LlamaIndex · CrewAI · AutoGen · Haystack · Google ADK · OpenAI Agents · Semantic Kernel · Pydantic AI · Agno · LiveKit · Pipecat · Claude Agent · Mastra · Vercel AI SDK · NeMo Agent Toolkit · Microsoft Agent Framework · DSPy · Smolagents · Camel-AI · Marvin · Mirascope</strong>
 </p>
 
 > **What's in this repo:** the open-source Python and JavaScript SDKs plus all framework integrations, licensed under Apache 2.0. The Synap memory engine itself — ingestion, entity resolution, retrieval, anticipation — runs as a fully managed cloud service operated by Maximem and is **not** open source. The SDKs in this repo are clients for that service; there is nothing to self-host, and an [API key](https://www.maximem.ai/synap) is required.
@@ -257,6 +257,11 @@ agent = ReActAgent.from_tools(tools, memory=memory)
 | Vercel AI SDK | [`@maximem/synap-vercel-adk`](packages/integrations/synap-vercel-adk/) | `npm i @maximem/synap-vercel-adk` |
 | NVIDIA NeMo Agent Toolkit | [`maximem-synap-nemo-agent-toolkit`](packages/integrations/synap-nemo-agent-toolkit/) | `pip install maximem-synap-nemo-agent-toolkit` |
 | Microsoft Agent Framework | [`maximem-synap-microsoft-agent`](packages/integrations/synap-microsoft-agent/) | `pip install maximem-synap-microsoft-agent` |
+| DSPy | [`maximem-synap-dspy`](packages/integrations/synap-dspy/) | `pip install maximem-synap-dspy` |
+| Smolagents | [`maximem-synap-smolagents`](packages/integrations/synap-smolagents/) | `pip install maximem-synap-smolagents` |
+| Camel-AI | [`maximem-synap-camel`](packages/integrations/synap-camel/) | `pip install maximem-synap-camel` |
+| Marvin | [`maximem-synap-marvin`](packages/integrations/synap-marvin/) | `pip install maximem-synap-marvin` |
+| Mirascope | [`maximem-synap-mirascope`](packages/integrations/synap-mirascope/) | `pip install maximem-synap-mirascope` |
 
 <!-- END integrations -->
 

--- a/packages/integrations/synap-camel/README.md
+++ b/packages/integrations/synap-camel/README.md
@@ -1,0 +1,31 @@
+# Synap + Camel-AI
+
+Synap memory tools and short-term context helpers for [Camel-AI](https://pypi.org/).
+
+## Install
+
+```bash
+pip install maximem-synap maximem-synap-camel
+```
+
+## Usage
+
+```python
+from maximem_synap import MaximemSynapSDK
+from synap_camel import create_search_tool, create_store_tool, synap_st_instructions
+
+sdk = MaximemSynapSDK(api_key="your-api-key")
+await sdk.initialize()
+
+search = create_search_tool(sdk, user_id="alice", conversation_id="conv-1")
+store = create_store_tool(sdk, user_id="alice")
+
+# ChatAgent(system_message=synap_st_instructions(...))
+instructions = synap_st_instructions(
+    sdk,
+    conversation_id="conv-1",
+    system="You are a helpful assistant.",
+)
+```
+
+See the root repo README for scoping (`user_id`, `customer_id`, `conversation_id`) and benchmark context.

--- a/packages/integrations/synap-camel/pyproject.toml
+++ b/packages/integrations/synap-camel/pyproject.toml
@@ -1,0 +1,23 @@
+[build-system]
+requires = ["setuptools>=61.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "maximem-synap-camel"
+version = "0.2.0"
+description = "Synap memory integration for Camel-AI"
+readme = "README.md"
+requires-python = ">=3.11"
+license = "Apache-2.0"
+dependencies = ["maximem-synap>=0.2.0", "maximem-synap-integrations-common>=0.1.0", "camel-ai>=0.2"]
+
+[project.optional-dependencies]
+dev = ["pytest>=7.0", "pytest-asyncio>=0.21"]
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["synap_camel*"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+asyncio_mode = "auto"

--- a/packages/integrations/synap-camel/synap_camel/__init__.py
+++ b/packages/integrations/synap-camel/synap_camel/__init__.py
@@ -1,0 +1,10 @@
+"""Synap memory integration for Camel-AI."""
+
+from synap_camel.short_term import synap_st_instructions
+from synap_camel.tools import create_search_tool, create_store_tool
+
+__all__ = [
+    "create_search_tool",
+    "create_store_tool",
+    "synap_st_instructions",
+]

--- a/packages/integrations/synap-camel/synap_camel/short_term.py
+++ b/packages/integrations/synap-camel/synap_camel/short_term.py
@@ -1,0 +1,163 @@
+"""Synap short-term context for Camel-AI.
+
+Mirrors the LangGraph template: a single thin wrapper around
+``sdk.conversation.context.get_context_for_prompt``. Quality contract is
+identical to the LangGraph adapter (see synap_langgraph.short_term).
+
+Camel-AI accepts ``Agent(instructions=...)`` where ``instructions``
+can be a string OR an async callable receiving ``(context, agent)`` and
+returning a string. :func:`synap_st_instructions` returns the second
+form: each agent step calls into the SDK helper (cache-first), prepends
+the ST block above your own system text inside the configured preamble
+tags, and returns the combined instructions string.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Awaitable, Callable, Literal, Optional
+
+from maximem_synap import MaximemSynapSDK
+from synap_integrations_common import (
+    SynapIntegrationError,
+    wrap_sdk_errors_async,
+)
+
+logger = logging.getLogger(__name__)
+
+_SUPPORTED_STYLES = ("structured", "narrative", "bullet_points")
+_DEFAULT_OPEN = "<synap_short_term_context>"
+_DEFAULT_CLOSE = "</synap_short_term_context>"
+
+_OnError = Literal["fallback", "raise"]
+
+
+def _validate_args(
+    sdk: Optional[MaximemSynapSDK],
+    conversation_id: str,
+    style: str,
+    on_error: str,
+    site: str,
+) -> None:
+    if sdk is None:
+        raise ValueError(f"{site} requires a non-None sdk")
+    if not conversation_id or not str(conversation_id).strip():
+        raise ValueError(f"{site} requires a non-empty conversation_id")
+    if style not in _SUPPORTED_STYLES:
+        raise ValueError(
+            f"{site}: unsupported style={style!r}; expected one of {_SUPPORTED_STYLES}"
+        )
+    if on_error not in ("fallback", "raise"):
+        raise ValueError(
+            f"{site}: on_error must be 'fallback' or 'raise', got {on_error!r}"
+        )
+
+
+async def _fetch_st_block(
+    sdk: MaximemSynapSDK,
+    conversation_id: str,
+    style: str,
+    on_error: _OnError,
+    site: str,
+) -> str:
+    try:
+        async with wrap_sdk_errors_async(
+            site,
+            logger,
+            conversation_id=conversation_id,
+            style=style,
+        ):
+            response = await sdk.conversation.context.get_context_for_prompt(
+                conversation_id=conversation_id,
+                style=style,
+            )
+    except SynapIntegrationError:
+        if on_error == "raise":
+            raise
+        return ""
+    if not getattr(response, "available", False):
+        return ""
+    formatted = getattr(response, "formatted_context", None)
+    return (formatted or "").strip()
+
+
+def _compose(
+    st_block: str,
+    user_system: str,
+    preamble_open: Optional[str],
+    preamble_close: Optional[str],
+) -> str:
+    parts = []
+    st_block = (st_block or "").strip()
+    user_system = (user_system or "").strip()
+    if st_block:
+        if preamble_open and preamble_close:
+            parts.append(f"{preamble_open}\n{st_block}\n{preamble_close}")
+        else:
+            parts.append(st_block)
+    if user_system:
+        parts.append(user_system)
+    return "\n\n".join(parts)
+
+
+def synap_st_instructions(
+    sdk: MaximemSynapSDK,
+    conversation_id: str,
+    *,
+    system: str = "",
+    style: str = "narrative",
+    preamble_open: Optional[str] = _DEFAULT_OPEN,
+    preamble_close: Optional[str] = _DEFAULT_CLOSE,
+    on_error: _OnError = "fallback",
+) -> Callable[[Any, Any], Awaitable[str]]:
+    """Return an async ``instructions`` callable for Camel-AI.
+
+    The callable matches Camel-AI' expected signature
+    ``async (context, agent) -> str``. Both arguments are ignored — we
+    use the explicitly-bound ``conversation_id`` rather than inferring
+    from any framework-internal session.
+
+    Args:
+        sdk: Initialised :class:`MaximemSynapSDK`.
+        conversation_id: Synap conversation ID. **Required.**
+        system: Your own agent instructions; ST is prepended above.
+        style: One of ``"structured" | "narrative" | "bullet_points"``.
+        preamble_open / preamble_close: Wrapping tags; pass ``None`` for
+            both to drop the tags.
+        on_error: ``"fallback"`` (default) returns bare ``system`` on
+            SDK failure; ``"raise"`` propagates :class:`SynapIntegrationError`.
+
+    Example::
+
+        # from Camel-AI import Agent  # example
+        from maximem_synap import MaximemSynapSDK
+        from synap_camel import synap_st_instructions
+
+        sdk = MaximemSynapSDK(api_key="sk-...")
+        agent = Agent(
+            name="support",
+            instructions=synap_st_instructions(
+                sdk,
+                conversation_id="conv_abc",
+                system="You are a polite support agent.",
+            ),
+            tools=[...],
+        )
+    """
+    _validate_args(sdk, conversation_id, style, on_error, "synap_st_instructions")
+
+    async def _instructions(context: Any, agent: Any) -> str:  # noqa: ARG001 — framework signature
+        st_block = await _fetch_st_block(
+            sdk,
+            conversation_id,
+            style,
+            on_error,
+            site="synap_camel.synap_st_instructions",
+        )
+        return _compose(st_block, system, preamble_open, preamble_close)
+
+    _instructions.__name__ = "synap_st_instructions"
+    return _instructions
+
+
+__all__ = ["synap_st_instructions"]

--- a/packages/integrations/synap-camel/synap_camel/tools.py
+++ b/packages/integrations/synap-camel/synap_camel/tools.py
@@ -1,0 +1,79 @@
+"""Synap tools for Camel-AI.
+
+Provides memory search/store callables for Camel-AI agents.
+SDK failures are wrapped in :class:`SynapIntegrationError`.
+"""
+
+import logging
+from typing import Optional
+
+from maximem_synap import MaximemSynapSDK
+from synap_integrations_common import wrap_sdk_errors_async
+
+logger = logging.getLogger(__name__)
+
+
+def create_search_tool(
+    sdk: MaximemSynapSDK,
+    user_id: str,
+    customer_id: str = "",
+    conversation_id: Optional[str] = None,
+):
+    """Create a memory search callable for Camel-AI.
+
+    Example::
+
+        search_fn = create_search_tool(sdk, user_id="u1")
+        # Wire into your Camel-AI agent: FunctionTool(search_memory)
+    """
+    if sdk is None:
+        raise ValueError("create_search_tool requires a non-None sdk")
+    if not user_id:
+        raise ValueError("create_search_tool requires a non-empty user_id")
+
+    async def search_memory(query: str) -> str:
+        """Search the user's memory for relevant context."""
+        async with wrap_sdk_errors_async(
+            "camel.search_memory",
+            logger,
+            user_id=user_id,
+        ):
+            response = await sdk.fetch(
+                conversation_id=conversation_id,
+                user_id=user_id,
+                customer_id=customer_id or None,
+                search_query=[query],
+                mode="accurate",
+                include_conversation_context=False,
+            )
+        return response.formatted_context or "No relevant memories found."
+
+    return search_memory
+
+
+def create_store_tool(
+    sdk: MaximemSynapSDK,
+    user_id: str,
+    customer_id: str = "",
+):
+    """Create a memory store callable for Camel-AI."""
+    if sdk is None:
+        raise ValueError("create_store_tool requires a non-None sdk")
+    if not user_id:
+        raise ValueError("create_store_tool requires a non-empty user_id")
+
+    async def store_memory(content: str) -> str:
+        """Store important information about the user for future reference."""
+        async with wrap_sdk_errors_async(
+            "camel.store_memory",
+            logger,
+            user_id=user_id,
+        ):
+            result = await sdk.memories.create(
+                document=content,
+                user_id=user_id,
+                customer_id=customer_id,
+            )
+        return f"Memory stored (ingestion_id: {result.ingestion_id})"
+
+    return store_memory

--- a/packages/integrations/synap-camel/tests/conftest.py
+++ b/packages/integrations/synap-camel/tests/conftest.py
@@ -1,0 +1,26 @@
+"""Pytest conftest for synap-openai-agents tests.
+
+Re-exports fixtures and factories from the shared harness so every test file
+can rely on a single, canonical source of truth.
+"""
+
+import sys
+import os
+
+# Ensure local packages are importable when running from repo root.
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../synap/sdk/python"))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(
+    0, os.path.join(os.path.dirname(__file__), "../../synap-integrations-common")
+)
+
+from synap_integrations_common.testing import (  # noqa: F401
+    mock_sdk,
+    failing_sdk,
+    make_fact,
+    make_preference,
+    make_episode,
+    make_emotion,
+    make_temporal_event,
+    make_unified_response,
+)

--- a/packages/integrations/synap-camel/tests/test_short_term.py
+++ b/packages/integrations/synap-camel/tests/test_short_term.py
@@ -1,0 +1,376 @@
+"""Tests for synap_camel.short_term — synap_st_instructions.
+
+Covers:
+- Construction validation (sdk=None, empty/whitespace conversation_id, unknown style,
+  invalid on_error)
+- Happy paths: ST block present, preamble wrapping, style forwarding, all 3 styles accepted
+- Empty-ST safety: unavailable flag, None formatted_context, empty string
+- Error policies: fallback (on_error="fallback") returns bare system, raise propagates
+  SynapIntegrationError
+- Callable contract: returned value is an async callable accepting (context, agent)
+- Harness: failing_sdk fixture
+- Public surface: __all__ exports
+"""
+
+from __future__ import annotations
+
+import inspect
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from synap_camel.short_term import synap_st_instructions
+from synap_integrations_common import SynapIntegrationError
+
+
+# ---------------------------------------------------------------------------
+# Local helpers — minimal, keep tests readable
+# ---------------------------------------------------------------------------
+
+
+def _make_response(formatted: str | None, available: bool = True):
+    resp = MagicMock()
+    resp.available = available
+    resp.formatted_context = formatted
+    return resp
+
+
+def _fake_sdk(
+    formatted: str | None = "User prefers concise replies.", available: bool = True
+):
+    sdk = MagicMock()
+    sdk.conversation.context.get_context_for_prompt = AsyncMock(
+        return_value=_make_response(formatted, available)
+    )
+    return sdk
+
+
+# ---------------------------------------------------------------------------
+# Construction validation
+# ---------------------------------------------------------------------------
+
+
+class TestValidation:
+    def test_requires_sdk(self):
+        with pytest.raises(ValueError, match="non-None sdk"):
+            synap_st_instructions(None, "conv_abc")  # type: ignore[arg-type]
+
+    def test_requires_nonempty_conversation_id(self):
+        sdk = _fake_sdk()
+        with pytest.raises(ValueError, match="non-empty conversation_id"):
+            synap_st_instructions(sdk, "")
+
+    def test_rejects_whitespace_only_conversation_id(self):
+        sdk = _fake_sdk()
+        with pytest.raises(ValueError, match="non-empty conversation_id"):
+            synap_st_instructions(sdk, "   ")
+
+    def test_rejects_unknown_style(self):
+        sdk = _fake_sdk()
+        with pytest.raises(ValueError, match="unsupported style"):
+            synap_st_instructions(sdk, "conv_abc", style="poetic")
+
+    def test_rejects_invalid_on_error(self):
+        sdk = _fake_sdk()
+        with pytest.raises(ValueError, match="on_error"):
+            synap_st_instructions(sdk, "conv_abc", on_error="ignore")  # type: ignore[arg-type]
+
+    def test_accepts_all_supported_styles(self):
+        sdk = _fake_sdk()
+        for style in ("structured", "narrative", "bullet_points"):
+            # Should NOT raise
+            fn = synap_st_instructions(sdk, "conv_abc", style=style)
+            assert callable(fn), f"should return callable for style={style!r}"
+
+
+# ---------------------------------------------------------------------------
+# Callable contract
+# ---------------------------------------------------------------------------
+
+
+class TestCallableContract:
+    def test_returns_async_callable(self):
+        sdk = _fake_sdk()
+        fn = synap_st_instructions(sdk, "conv_abc")
+        assert callable(fn)
+        assert inspect.iscoroutinefunction(fn), "instructions must be async"
+
+    def test_callable_is_named(self):
+        sdk = _fake_sdk()
+        fn = synap_st_instructions(sdk, "conv_abc")
+        assert fn.__name__ == "synap_st_instructions"
+
+    @pytest.mark.asyncio
+    async def test_accepts_two_positional_args(self):
+        """OpenAI Agents calls instructions(context, agent) — both args must be accepted."""
+        sdk = _fake_sdk(formatted="ctx")
+        fn = synap_st_instructions(sdk, "conv_abc", system="sys")
+        # Should not raise with two MagicMock positional arguments
+        result = await fn(MagicMock(), MagicMock())
+        assert isinstance(result, str)
+
+
+# ---------------------------------------------------------------------------
+# Happy paths — ST present
+# ---------------------------------------------------------------------------
+
+
+class TestHappyPath:
+    @pytest.mark.asyncio
+    async def test_returns_combined_instructions_with_default_preamble(self):
+        sdk = _fake_sdk(formatted="User likes Markdown.")
+        instr = synap_st_instructions(sdk, "conv_abc", system="You are a coding agent.")
+        result = await instr(MagicMock(), MagicMock())
+        assert "<synap_short_term_context>" in result
+        assert "User likes Markdown." in result
+        assert "</synap_short_term_context>" in result
+        assert "You are a coding agent." in result
+        # ST block must appear before user system text
+        assert result.index("User likes Markdown") < result.index("coding agent")
+
+    @pytest.mark.asyncio
+    async def test_passes_conversation_id_and_style_to_sdk(self):
+        sdk = _fake_sdk()
+        instr = synap_st_instructions(
+            sdk, "conv_xyz", style="bullet_points", system="X"
+        )
+        await instr(MagicMock(), MagicMock())
+        sdk.conversation.context.get_context_for_prompt.assert_awaited_once_with(
+            conversation_id="conv_xyz",
+            style="bullet_points",
+        )
+
+    @pytest.mark.asyncio
+    async def test_default_style_is_narrative(self):
+        sdk = _fake_sdk()
+        instr = synap_st_instructions(sdk, "conv_abc", system="X")
+        await instr(MagicMock(), MagicMock())
+        sdk.conversation.context.get_context_for_prompt.assert_awaited_once_with(
+            conversation_id="conv_abc",
+            style="narrative",
+        )
+
+    @pytest.mark.asyncio
+    async def test_custom_preamble_tags(self):
+        sdk = _fake_sdk(formatted="X")
+        instr = synap_st_instructions(
+            sdk,
+            "conv_abc",
+            system="sys",
+            preamble_open="[BEGIN]",
+            preamble_close="[END]",
+        )
+        out = await instr(MagicMock(), MagicMock())
+        assert "[BEGIN]" in out
+        assert "[END]" in out
+        assert "<synap_short_term_context>" not in out
+
+    @pytest.mark.asyncio
+    async def test_no_preamble_raw_concat(self):
+        """When both preamble tags are None, ST and system are joined with double newline."""
+        sdk = _fake_sdk(formatted="raw st")
+        instr = synap_st_instructions(
+            sdk,
+            "conv_abc",
+            system="user sys",
+            preamble_open=None,
+            preamble_close=None,
+        )
+        out = await instr(MagicMock(), MagicMock())
+        assert out == "raw st\n\nuser sys"
+
+    @pytest.mark.asyncio
+    async def test_st_only_no_system(self):
+        """When system is empty, only the ST block (with preamble) is returned."""
+        sdk = _fake_sdk(formatted="context block")
+        instr = synap_st_instructions(sdk, "conv_abc", system="")
+        out = await instr(MagicMock(), MagicMock())
+        assert "context block" in out
+        assert "<synap_short_term_context>" in out
+
+    @pytest.mark.asyncio
+    async def test_structured_style_forwarded(self):
+        sdk = _fake_sdk()
+        instr = synap_st_instructions(sdk, "conv_abc", style="structured")
+        await instr(MagicMock(), MagicMock())
+        sdk.conversation.context.get_context_for_prompt.assert_awaited_once_with(
+            conversation_id="conv_abc",
+            style="structured",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Empty / unavailable ST
+# ---------------------------------------------------------------------------
+
+
+class TestEmptyST:
+    @pytest.mark.asyncio
+    async def test_unavailable_returns_user_system_only(self):
+        sdk = _fake_sdk(formatted=None, available=False)
+        instr = synap_st_instructions(sdk, "conv_abc", system="You are friendly.")
+        out = await instr(MagicMock(), MagicMock())
+        assert out == "You are friendly."
+
+    @pytest.mark.asyncio
+    async def test_unavailable_empty_system_returns_empty_string(self):
+        sdk = _fake_sdk(formatted=None, available=False)
+        instr = synap_st_instructions(sdk, "conv_abc", system="")
+        out = await instr(MagicMock(), MagicMock())
+        assert out == ""
+
+    @pytest.mark.asyncio
+    async def test_none_formatted_context_with_available_true_treated_as_empty(self):
+        """Even if available=True, a None formatted_context yields no ST block."""
+        sdk = _fake_sdk(formatted=None, available=True)
+        instr = synap_st_instructions(sdk, "conv_abc", system="sys")
+        out = await instr(MagicMock(), MagicMock())
+        assert out == "sys"
+        assert "<synap_short_term_context>" not in out
+
+    @pytest.mark.asyncio
+    async def test_empty_string_formatted_context_treated_as_empty(self):
+        sdk = _fake_sdk(formatted="", available=True)
+        instr = synap_st_instructions(sdk, "conv_abc", system="sys")
+        out = await instr(MagicMock(), MagicMock())
+        assert out == "sys"
+
+    @pytest.mark.asyncio
+    async def test_whitespace_only_formatted_context_treated_as_empty(self):
+        sdk = _fake_sdk(formatted="   ", available=True)
+        instr = synap_st_instructions(sdk, "conv_abc", system="sys")
+        out = await instr(MagicMock(), MagicMock())
+        assert out == "sys"
+
+
+# ---------------------------------------------------------------------------
+# Error policies
+# ---------------------------------------------------------------------------
+
+
+class TestErrorPolicies:
+    @pytest.mark.asyncio
+    async def test_fallback_on_sdk_failure_returns_user_system(self):
+        sdk = MagicMock()
+        sdk.conversation.context.get_context_for_prompt = AsyncMock(
+            side_effect=RuntimeError("sdk boom")
+        )
+        instr = synap_st_instructions(
+            sdk, "conv_abc", system="Stay calm.", on_error="fallback"
+        )
+        out = await instr(MagicMock(), MagicMock())
+        assert out == "Stay calm."
+
+    @pytest.mark.asyncio
+    async def test_fallback_empty_system_returns_empty_string(self):
+        sdk = MagicMock()
+        sdk.conversation.context.get_context_for_prompt = AsyncMock(
+            side_effect=RuntimeError("sdk boom")
+        )
+        instr = synap_st_instructions(sdk, "conv_abc", system="", on_error="fallback")
+        out = await instr(MagicMock(), MagicMock())
+        assert out == ""
+
+    @pytest.mark.asyncio
+    async def test_raise_propagates_synap_integration_error(self):
+        sdk = MagicMock()
+        sdk.conversation.context.get_context_for_prompt = AsyncMock(
+            side_effect=RuntimeError("sdk boom")
+        )
+        instr = synap_st_instructions(sdk, "conv_abc", system="X", on_error="raise")
+        with pytest.raises(SynapIntegrationError):
+            await instr(MagicMock(), MagicMock())
+
+    @pytest.mark.asyncio
+    async def test_raise_chains_original_cause(self):
+        original = RuntimeError("original sdk error")
+        sdk = MagicMock()
+        sdk.conversation.context.get_context_for_prompt = AsyncMock(
+            side_effect=original
+        )
+        instr = synap_st_instructions(sdk, "conv_abc", system="X", on_error="raise")
+        with pytest.raises(SynapIntegrationError) as exc_info:
+            await instr(MagicMock(), MagicMock())
+        assert exc_info.value.__cause__ is original
+
+    @pytest.mark.asyncio
+    async def test_synap_integration_error_passthrough_on_raise(self):
+        """A SynapIntegrationError raised by the SDK should propagate without double-wrapping."""
+        sdk = MagicMock()
+        original = SynapIntegrationError("op", "direct error")
+        sdk.conversation.context.get_context_for_prompt = AsyncMock(
+            side_effect=original
+        )
+        instr = synap_st_instructions(sdk, "conv_abc", system="X", on_error="raise")
+        with pytest.raises(SynapIntegrationError) as exc_info:
+            await instr(MagicMock(), MagicMock())
+        # Should be exactly the original instance (not a new wrapper)
+        assert exc_info.value is original
+
+
+# ---------------------------------------------------------------------------
+# failing_sdk harness fixture
+# ---------------------------------------------------------------------------
+
+
+class TestFailingSdkHarness:
+    @pytest.mark.asyncio
+    async def test_fallback_with_failing_sdk(self, failing_sdk):
+        """failing_sdk triggers fallback; system text is returned unmodified."""
+        instr = synap_st_instructions(
+            failing_sdk, "conv_abc", system="fallback text", on_error="fallback"
+        )
+        out = await instr(MagicMock(), MagicMock())
+        assert out == "fallback text"
+
+    @pytest.mark.asyncio
+    async def test_raise_with_failing_sdk_surfaces_error(self, failing_sdk):
+        """failing_sdk with on_error='raise' must propagate as SynapIntegrationError."""
+        instr = synap_st_instructions(
+            failing_sdk, "conv_abc", system="X", on_error="raise"
+        )
+        with pytest.raises(SynapIntegrationError):
+            await instr(MagicMock(), MagicMock())
+
+
+# ---------------------------------------------------------------------------
+# mock_sdk harness fixture
+# ---------------------------------------------------------------------------
+
+
+class TestMockSdkHarness:
+    @pytest.mark.asyncio
+    async def test_mock_sdk_happy_path(self, mock_sdk):
+        """mock_sdk pre-wires get_context_for_prompt → returns a combined instructions string."""
+        instr = synap_st_instructions(
+            mock_sdk, "conv_abc", system="Agent system prompt."
+        )
+        out = await instr(MagicMock(), MagicMock())
+        assert isinstance(out, str)
+        # Combined output contains ST and user system text
+        assert "Agent system prompt." in out
+
+
+# ---------------------------------------------------------------------------
+# Public surface
+# ---------------------------------------------------------------------------
+
+
+class TestPublicSurface:
+    def test_module_exports_synap_st_instructions(self):
+        import synap_camel
+
+        assert hasattr(synap_camel, "synap_st_instructions")
+        assert "synap_st_instructions" in synap_camel.__all__
+
+    def test_create_search_tool_exported(self):
+        import synap_camel
+
+        assert hasattr(synap_camel, "create_search_tool")
+        assert "create_search_tool" in synap_camel.__all__
+
+    def test_create_store_tool_exported(self):
+        import synap_camel
+
+        assert hasattr(synap_camel, "create_store_tool")
+        assert "create_store_tool" in synap_camel.__all__

--- a/packages/integrations/synap-camel/tests/test_tools.py
+++ b/packages/integrations/synap-camel/tests/test_tools.py
@@ -1,0 +1,324 @@
+"""Tests for synap_camel.tools — create_search_tool / create_store_tool.
+
+Documented error-handling contract (from tools.py / wrap_sdk_errors_async):
+- Both factory functions validate sdk != None and user_id != "".
+- The returned async callables wrap SDK errors as SynapIntegrationError.
+- Callers (agent frameworks / test harnesses) decide how to handle the error.
+
+Covers:
+- Construction validation: sdk=None, empty user_id for both factories
+- search_memory happy paths: result forwarding, kwargs forwarded to sdk.fetch,
+  None/empty formatted_context fallback sentinel, conversation_id threading,
+  customer_id threading
+- store_memory happy paths: ingestion_id in return, kwargs forwarded to
+  sdk.memories.create, customer_id pass-through
+- Failure paths: SynapIntegrationError raised on SDK failure (both tools)
+- failing_sdk harness fixture
+- Public surface exports
+"""
+
+from __future__ import annotations
+
+import inspect
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from synap_camel.tools import create_search_tool, create_store_tool
+from synap_integrations_common import SynapIntegrationError
+
+
+# ---------------------------------------------------------------------------
+# Local helper: minimal SDK mock (unit-level, independent of shared harness)
+# ---------------------------------------------------------------------------
+
+
+def _sdk(fetch_return=None, create_return=None):
+    sdk = MagicMock()
+    sdk.fetch = AsyncMock(
+        return_value=fetch_return or MagicMock(formatted_context="ctx")
+    )
+    sdk.memories = MagicMock()
+    sdk.memories.create = AsyncMock(
+        return_value=create_return or MagicMock(ingestion_id="ing-001")
+    )
+    return sdk
+
+
+# ---------------------------------------------------------------------------
+# Public surface
+# ---------------------------------------------------------------------------
+
+
+def test_package_exports_create_search_tool():
+    from synap_camel import create_search_tool
+
+    assert create_search_tool is not None
+
+
+def test_package_exports_create_store_tool():
+    from synap_camel import create_store_tool
+
+    assert create_store_tool is not None
+
+
+# ---------------------------------------------------------------------------
+# create_search_tool — construction validation
+# ---------------------------------------------------------------------------
+
+
+class TestCreateSearchToolValidation:
+    def test_raises_on_none_sdk(self):
+        with pytest.raises(ValueError, match="non-None sdk"):
+            create_search_tool(None, user_id="u1")  # type: ignore[arg-type]
+
+    def test_raises_on_empty_user_id(self):
+        sdk = _sdk()
+        with pytest.raises(ValueError, match="non-empty user_id"):
+            create_search_tool(sdk, user_id="")
+
+    def test_returns_async_callable(self):
+        sdk = _sdk()
+        fn = create_search_tool(sdk, user_id="u1")
+        assert callable(fn)
+        assert inspect.iscoroutinefunction(fn), "search_memory must be async"
+
+
+# ---------------------------------------------------------------------------
+# create_search_tool — happy paths
+# ---------------------------------------------------------------------------
+
+
+class TestSearchToolHappyPath:
+    @pytest.mark.asyncio
+    async def test_returns_formatted_context(self):
+        sdk = _sdk(fetch_return=MagicMock(formatted_context="User likes tea"))
+        search = create_search_tool(sdk, user_id="u1")
+        result = await search(query="tea")
+        assert result == "User likes tea"
+
+    @pytest.mark.asyncio
+    async def test_forwards_query_as_list(self):
+        sdk = _sdk()
+        search = create_search_tool(sdk, user_id="u1")
+        await search(query="coffee preferences")
+        sdk.fetch.assert_awaited_once()
+        assert sdk.fetch.call_args.kwargs["search_query"] == ["coffee preferences"]
+
+    @pytest.mark.asyncio
+    async def test_forwards_user_id(self):
+        sdk = _sdk()
+        search = create_search_tool(sdk, user_id="user-42")
+        await search(query="q")
+        assert sdk.fetch.call_args.kwargs["user_id"] == "user-42"
+
+    @pytest.mark.asyncio
+    async def test_mode_is_accurate(self):
+        sdk = _sdk()
+        search = create_search_tool(sdk, user_id="u1")
+        await search(query="q")
+        assert sdk.fetch.call_args.kwargs["mode"] == "accurate"
+
+    @pytest.mark.asyncio
+    async def test_include_conversation_context_is_false(self):
+        sdk = _sdk()
+        search = create_search_tool(sdk, user_id="u1")
+        await search(query="q")
+        assert sdk.fetch.call_args.kwargs["include_conversation_context"] is False
+
+    @pytest.mark.asyncio
+    async def test_none_formatted_context_returns_sentinel(self):
+        sdk = _sdk(fetch_return=MagicMock(formatted_context=None))
+        search = create_search_tool(sdk, user_id="u1")
+        result = await search(query="unknown")
+        assert result == "No relevant memories found."
+
+    @pytest.mark.asyncio
+    async def test_empty_string_formatted_context_returns_sentinel(self):
+        sdk = _sdk(fetch_return=MagicMock(formatted_context=""))
+        search = create_search_tool(sdk, user_id="u1")
+        result = await search(query="unknown")
+        assert result == "No relevant memories found."
+
+    @pytest.mark.asyncio
+    async def test_conversation_id_forwarded_when_provided(self):
+        sdk = _sdk()
+        search = create_search_tool(sdk, user_id="u1", conversation_id="conv-99")
+        await search(query="q")
+        assert sdk.fetch.call_args.kwargs["conversation_id"] == "conv-99"
+
+    @pytest.mark.asyncio
+    async def test_conversation_id_none_when_not_provided(self):
+        sdk = _sdk()
+        search = create_search_tool(sdk, user_id="u1")
+        await search(query="q")
+        # None or not present — depends on implementation; either is acceptable
+        kwargs = sdk.fetch.call_args.kwargs
+        assert kwargs.get("conversation_id") is None
+
+    @pytest.mark.asyncio
+    async def test_customer_id_forwarded(self):
+        sdk = _sdk()
+        search = create_search_tool(sdk, user_id="u1", customer_id="cust-7")
+        await search(query="q")
+        kwargs = sdk.fetch.call_args.kwargs
+        # customer_id='' maps to None internally; non-empty is forwarded as-is
+        assert kwargs.get("customer_id") == "cust-7"
+
+    @pytest.mark.asyncio
+    async def test_empty_customer_id_coerced_to_none(self):
+        """Empty customer_id is coerced to None before sdk.fetch per product code."""
+        sdk = _sdk()
+        search = create_search_tool(sdk, user_id="u1", customer_id="")
+        await search(query="q")
+        kwargs = sdk.fetch.call_args.kwargs
+        assert kwargs.get("customer_id") is None
+
+
+# ---------------------------------------------------------------------------
+# create_search_tool — failure paths
+# ---------------------------------------------------------------------------
+
+
+class TestSearchToolFailurePath:
+    @pytest.mark.asyncio
+    async def test_raises_synap_integration_error_on_sdk_failure(self):
+        sdk = _sdk()
+        sdk.fetch = AsyncMock(side_effect=RuntimeError("sdk boom"))
+        search = create_search_tool(sdk, user_id="u1")
+        with pytest.raises(SynapIntegrationError):
+            await search(query="any query")
+
+    @pytest.mark.asyncio
+    async def test_synap_integration_error_chains_original_cause(self):
+        original = RuntimeError("original sdk error")
+        sdk = _sdk()
+        sdk.fetch = AsyncMock(side_effect=original)
+        search = create_search_tool(sdk, user_id="u1")
+        with pytest.raises(SynapIntegrationError) as exc_info:
+            await search(query="q")
+        assert exc_info.value.__cause__ is original
+
+    @pytest.mark.asyncio
+    async def test_failing_sdk_search_raises(self, failing_sdk):
+        """Shared failing_sdk fixture — get_context_for_prompt raises RuntimeError."""
+        # failing_sdk wires sdk.fetch to raise; so create_search_tool must propagate
+        search = create_search_tool(failing_sdk, user_id="u1")
+        with pytest.raises(SynapIntegrationError):
+            await search(query="anything")
+
+
+# ---------------------------------------------------------------------------
+# create_store_tool — construction validation
+# ---------------------------------------------------------------------------
+
+
+class TestCreateStoreToolValidation:
+    def test_raises_on_none_sdk(self):
+        with pytest.raises(ValueError, match="non-None sdk"):
+            create_store_tool(None, user_id="u1")  # type: ignore[arg-type]
+
+    def test_raises_on_empty_user_id(self):
+        sdk = _sdk()
+        with pytest.raises(ValueError, match="non-empty user_id"):
+            create_store_tool(sdk, user_id="")
+
+    def test_returns_async_callable(self):
+        sdk = _sdk()
+        fn = create_store_tool(sdk, user_id="u1")
+        assert callable(fn)
+        assert inspect.iscoroutinefunction(fn), "store_memory must be async"
+
+
+# ---------------------------------------------------------------------------
+# create_store_tool — happy paths
+# ---------------------------------------------------------------------------
+
+
+class TestStoreToolHappyPath:
+    @pytest.mark.asyncio
+    async def test_returns_string_with_ingestion_id(self):
+        sdk = _sdk(create_return=MagicMock(ingestion_id="ing-123"))
+        store = create_store_tool(sdk, user_id="u1")
+        result = await store(content="User prefers dark mode")
+        assert "ing-123" in result
+
+    @pytest.mark.asyncio
+    async def test_returns_string(self):
+        sdk = _sdk()
+        store = create_store_tool(sdk, user_id="u1")
+        result = await store(content="some content")
+        assert isinstance(result, str)
+
+    @pytest.mark.asyncio
+    async def test_forwards_document_to_memories_create(self):
+        sdk = _sdk()
+        store = create_store_tool(sdk, user_id="u1")
+        await store(content="User prefers dark mode")
+        sdk.memories.create.assert_awaited_once()
+        kwargs = sdk.memories.create.call_args.kwargs
+        assert kwargs["document"] == "User prefers dark mode"
+
+    @pytest.mark.asyncio
+    async def test_forwards_user_id_to_memories_create(self):
+        sdk = _sdk()
+        store = create_store_tool(sdk, user_id="user-99")
+        await store(content="some info")
+        kwargs = sdk.memories.create.call_args.kwargs
+        assert kwargs["user_id"] == "user-99"
+
+    @pytest.mark.asyncio
+    async def test_forwards_customer_id_to_memories_create(self):
+        sdk = _sdk()
+        store = create_store_tool(sdk, user_id="u1", customer_id="cust-42")
+        await store(content="info")
+        kwargs = sdk.memories.create.call_args.kwargs
+        assert kwargs["customer_id"] == "cust-42"
+
+    @pytest.mark.asyncio
+    async def test_empty_customer_id_forwarded_as_empty_string(self):
+        """Default customer_id='' is passed through to memories.create unchanged."""
+        sdk = _sdk()
+        store = create_store_tool(sdk, user_id="u1")
+        await store(content="info")
+        kwargs = sdk.memories.create.call_args.kwargs
+        assert kwargs["customer_id"] == ""
+
+    @pytest.mark.asyncio
+    async def test_mock_sdk_store_happy_path(self, mock_sdk):
+        """Shared mock_sdk harness: memories.create pre-wired to return ingestion_id=ing-001."""
+        store = create_store_tool(mock_sdk, user_id="u1")
+        result = await store(content="remember this")
+        assert "ing-001" in result
+
+
+# ---------------------------------------------------------------------------
+# create_store_tool — failure paths
+# ---------------------------------------------------------------------------
+
+
+class TestStoreToolFailurePath:
+    @pytest.mark.asyncio
+    async def test_raises_synap_integration_error_on_sdk_failure(self):
+        sdk = _sdk()
+        sdk.memories.create = AsyncMock(side_effect=RuntimeError("sdk boom"))
+        store = create_store_tool(sdk, user_id="u1")
+        with pytest.raises(SynapIntegrationError):
+            await store(content="content to store")
+
+    @pytest.mark.asyncio
+    async def test_synap_integration_error_chains_original_cause(self):
+        original = RuntimeError("original error")
+        sdk = _sdk()
+        sdk.memories.create = AsyncMock(side_effect=original)
+        store = create_store_tool(sdk, user_id="u1")
+        with pytest.raises(SynapIntegrationError) as exc_info:
+            await store(content="content")
+        assert exc_info.value.__cause__ is original
+
+    @pytest.mark.asyncio
+    async def test_failing_sdk_store_raises(self, failing_sdk):
+        """Shared failing_sdk fixture — sdk.memories.create raises RuntimeError."""
+        store = create_store_tool(failing_sdk, user_id="u1")
+        with pytest.raises(SynapIntegrationError):
+            await store(content="anything")

--- a/packages/integrations/synap-dspy/README.md
+++ b/packages/integrations/synap-dspy/README.md
@@ -1,0 +1,31 @@
+# Synap + DSPy
+
+Synap memory tools and short-term context helpers for [DSPy](https://pypi.org/).
+
+## Install
+
+```bash
+pip install maximem-synap maximem-synap-dspy
+```
+
+## Usage
+
+```python
+from maximem_synap import MaximemSynapSDK
+from synap_dspy import create_search_tool, create_store_tool, synap_st_instructions
+
+sdk = MaximemSynapSDK(api_key="your-api-key")
+await sdk.initialize()
+
+search = create_search_tool(sdk, user_id="alice", conversation_id="conv-1")
+store = create_store_tool(sdk, user_id="alice")
+
+# dspy.Module with synap_st_instructions as system prefix
+instructions = synap_st_instructions(
+    sdk,
+    conversation_id="conv-1",
+    system="You are a helpful assistant.",
+)
+```
+
+See the root repo README for scoping (`user_id`, `customer_id`, `conversation_id`) and benchmark context.

--- a/packages/integrations/synap-dspy/pyproject.toml
+++ b/packages/integrations/synap-dspy/pyproject.toml
@@ -1,0 +1,23 @@
+[build-system]
+requires = ["setuptools>=61.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "maximem-synap-dspy"
+version = "0.2.0"
+description = "Synap memory integration for DSPy"
+readme = "README.md"
+requires-python = ">=3.11"
+license = "Apache-2.0"
+dependencies = ["maximem-synap>=0.2.0", "maximem-synap-integrations-common>=0.1.0", "dspy>=2.5"]
+
+[project.optional-dependencies]
+dev = ["pytest>=7.0", "pytest-asyncio>=0.21"]
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["synap_dspy*"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+asyncio_mode = "auto"

--- a/packages/integrations/synap-dspy/synap_dspy/__init__.py
+++ b/packages/integrations/synap-dspy/synap_dspy/__init__.py
@@ -1,0 +1,10 @@
+"""Synap memory integration for DSPy."""
+
+from synap_dspy.short_term import synap_st_instructions
+from synap_dspy.tools import create_search_tool, create_store_tool
+
+__all__ = [
+    "create_search_tool",
+    "create_store_tool",
+    "synap_st_instructions",
+]

--- a/packages/integrations/synap-dspy/synap_dspy/short_term.py
+++ b/packages/integrations/synap-dspy/synap_dspy/short_term.py
@@ -1,0 +1,163 @@
+"""Synap short-term context for DSPy.
+
+Mirrors the LangGraph template: a single thin wrapper around
+``sdk.conversation.context.get_context_for_prompt``. Quality contract is
+identical to the LangGraph adapter (see synap_langgraph.short_term).
+
+DSPy accepts ``Agent(instructions=...)`` where ``instructions``
+can be a string OR an async callable receiving ``(context, agent)`` and
+returning a string. :func:`synap_st_instructions` returns the second
+form: each agent step calls into the SDK helper (cache-first), prepends
+the ST block above your own system text inside the configured preamble
+tags, and returns the combined instructions string.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Awaitable, Callable, Literal, Optional
+
+from maximem_synap import MaximemSynapSDK
+from synap_integrations_common import (
+    SynapIntegrationError,
+    wrap_sdk_errors_async,
+)
+
+logger = logging.getLogger(__name__)
+
+_SUPPORTED_STYLES = ("structured", "narrative", "bullet_points")
+_DEFAULT_OPEN = "<synap_short_term_context>"
+_DEFAULT_CLOSE = "</synap_short_term_context>"
+
+_OnError = Literal["fallback", "raise"]
+
+
+def _validate_args(
+    sdk: Optional[MaximemSynapSDK],
+    conversation_id: str,
+    style: str,
+    on_error: str,
+    site: str,
+) -> None:
+    if sdk is None:
+        raise ValueError(f"{site} requires a non-None sdk")
+    if not conversation_id or not str(conversation_id).strip():
+        raise ValueError(f"{site} requires a non-empty conversation_id")
+    if style not in _SUPPORTED_STYLES:
+        raise ValueError(
+            f"{site}: unsupported style={style!r}; expected one of {_SUPPORTED_STYLES}"
+        )
+    if on_error not in ("fallback", "raise"):
+        raise ValueError(
+            f"{site}: on_error must be 'fallback' or 'raise', got {on_error!r}"
+        )
+
+
+async def _fetch_st_block(
+    sdk: MaximemSynapSDK,
+    conversation_id: str,
+    style: str,
+    on_error: _OnError,
+    site: str,
+) -> str:
+    try:
+        async with wrap_sdk_errors_async(
+            site,
+            logger,
+            conversation_id=conversation_id,
+            style=style,
+        ):
+            response = await sdk.conversation.context.get_context_for_prompt(
+                conversation_id=conversation_id,
+                style=style,
+            )
+    except SynapIntegrationError:
+        if on_error == "raise":
+            raise
+        return ""
+    if not getattr(response, "available", False):
+        return ""
+    formatted = getattr(response, "formatted_context", None)
+    return (formatted or "").strip()
+
+
+def _compose(
+    st_block: str,
+    user_system: str,
+    preamble_open: Optional[str],
+    preamble_close: Optional[str],
+) -> str:
+    parts = []
+    st_block = (st_block or "").strip()
+    user_system = (user_system or "").strip()
+    if st_block:
+        if preamble_open and preamble_close:
+            parts.append(f"{preamble_open}\n{st_block}\n{preamble_close}")
+        else:
+            parts.append(st_block)
+    if user_system:
+        parts.append(user_system)
+    return "\n\n".join(parts)
+
+
+def synap_st_instructions(
+    sdk: MaximemSynapSDK,
+    conversation_id: str,
+    *,
+    system: str = "",
+    style: str = "narrative",
+    preamble_open: Optional[str] = _DEFAULT_OPEN,
+    preamble_close: Optional[str] = _DEFAULT_CLOSE,
+    on_error: _OnError = "fallback",
+) -> Callable[[Any, Any], Awaitable[str]]:
+    """Return an async ``instructions`` callable for DSPy.
+
+    The callable matches DSPy' expected signature
+    ``async (context, agent) -> str``. Both arguments are ignored — we
+    use the explicitly-bound ``conversation_id`` rather than inferring
+    from any framework-internal session.
+
+    Args:
+        sdk: Initialised :class:`MaximemSynapSDK`.
+        conversation_id: Synap conversation ID. **Required.**
+        system: Your own agent instructions; ST is prepended above.
+        style: One of ``"structured" | "narrative" | "bullet_points"``.
+        preamble_open / preamble_close: Wrapping tags; pass ``None`` for
+            both to drop the tags.
+        on_error: ``"fallback"`` (default) returns bare ``system`` on
+            SDK failure; ``"raise"`` propagates :class:`SynapIntegrationError`.
+
+    Example::
+
+        # from DSPy import Agent  # example
+        from maximem_synap import MaximemSynapSDK
+        from synap_dspy import synap_st_instructions
+
+        sdk = MaximemSynapSDK(api_key="sk-...")
+        agent = Agent(
+            name="support",
+            instructions=synap_st_instructions(
+                sdk,
+                conversation_id="conv_abc",
+                system="You are a polite support agent.",
+            ),
+            tools=[...],
+        )
+    """
+    _validate_args(sdk, conversation_id, style, on_error, "synap_st_instructions")
+
+    async def _instructions(context: Any, agent: Any) -> str:  # noqa: ARG001 — framework signature
+        st_block = await _fetch_st_block(
+            sdk,
+            conversation_id,
+            style,
+            on_error,
+            site="synap_dspy.synap_st_instructions",
+        )
+        return _compose(st_block, system, preamble_open, preamble_close)
+
+    _instructions.__name__ = "synap_st_instructions"
+    return _instructions
+
+
+__all__ = ["synap_st_instructions"]

--- a/packages/integrations/synap-dspy/synap_dspy/tools.py
+++ b/packages/integrations/synap-dspy/synap_dspy/tools.py
@@ -1,0 +1,79 @@
+"""Synap tools for DSPy.
+
+Provides memory search/store callables for DSPy agents.
+SDK failures are wrapped in :class:`SynapIntegrationError`.
+"""
+
+import logging
+from typing import Optional
+
+from maximem_synap import MaximemSynapSDK
+from synap_integrations_common import wrap_sdk_errors_async
+
+logger = logging.getLogger(__name__)
+
+
+def create_search_tool(
+    sdk: MaximemSynapSDK,
+    user_id: str,
+    customer_id: str = "",
+    conversation_id: Optional[str] = None,
+):
+    """Create a memory search callable for DSPy.
+
+    Example::
+
+        search_fn = create_search_tool(sdk, user_id="u1")
+        # Wire into your DSPy agent: dspy.Tool(search_memory)
+    """
+    if sdk is None:
+        raise ValueError("create_search_tool requires a non-None sdk")
+    if not user_id:
+        raise ValueError("create_search_tool requires a non-empty user_id")
+
+    async def search_memory(query: str) -> str:
+        """Search the user's memory for relevant context."""
+        async with wrap_sdk_errors_async(
+            "dspy.search_memory",
+            logger,
+            user_id=user_id,
+        ):
+            response = await sdk.fetch(
+                conversation_id=conversation_id,
+                user_id=user_id,
+                customer_id=customer_id or None,
+                search_query=[query],
+                mode="accurate",
+                include_conversation_context=False,
+            )
+        return response.formatted_context or "No relevant memories found."
+
+    return search_memory
+
+
+def create_store_tool(
+    sdk: MaximemSynapSDK,
+    user_id: str,
+    customer_id: str = "",
+):
+    """Create a memory store callable for DSPy."""
+    if sdk is None:
+        raise ValueError("create_store_tool requires a non-None sdk")
+    if not user_id:
+        raise ValueError("create_store_tool requires a non-empty user_id")
+
+    async def store_memory(content: str) -> str:
+        """Store important information about the user for future reference."""
+        async with wrap_sdk_errors_async(
+            "dspy.store_memory",
+            logger,
+            user_id=user_id,
+        ):
+            result = await sdk.memories.create(
+                document=content,
+                user_id=user_id,
+                customer_id=customer_id,
+            )
+        return f"Memory stored (ingestion_id: {result.ingestion_id})"
+
+    return store_memory

--- a/packages/integrations/synap-dspy/tests/conftest.py
+++ b/packages/integrations/synap-dspy/tests/conftest.py
@@ -1,0 +1,26 @@
+"""Pytest conftest for synap-openai-agents tests.
+
+Re-exports fixtures and factories from the shared harness so every test file
+can rely on a single, canonical source of truth.
+"""
+
+import sys
+import os
+
+# Ensure local packages are importable when running from repo root.
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../synap/sdk/python"))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(
+    0, os.path.join(os.path.dirname(__file__), "../../synap-integrations-common")
+)
+
+from synap_integrations_common.testing import (  # noqa: F401
+    mock_sdk,
+    failing_sdk,
+    make_fact,
+    make_preference,
+    make_episode,
+    make_emotion,
+    make_temporal_event,
+    make_unified_response,
+)

--- a/packages/integrations/synap-dspy/tests/test_short_term.py
+++ b/packages/integrations/synap-dspy/tests/test_short_term.py
@@ -1,0 +1,376 @@
+"""Tests for synap_dspy.short_term — synap_st_instructions.
+
+Covers:
+- Construction validation (sdk=None, empty/whitespace conversation_id, unknown style,
+  invalid on_error)
+- Happy paths: ST block present, preamble wrapping, style forwarding, all 3 styles accepted
+- Empty-ST safety: unavailable flag, None formatted_context, empty string
+- Error policies: fallback (on_error="fallback") returns bare system, raise propagates
+  SynapIntegrationError
+- Callable contract: returned value is an async callable accepting (context, agent)
+- Harness: failing_sdk fixture
+- Public surface: __all__ exports
+"""
+
+from __future__ import annotations
+
+import inspect
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from synap_dspy.short_term import synap_st_instructions
+from synap_integrations_common import SynapIntegrationError
+
+
+# ---------------------------------------------------------------------------
+# Local helpers — minimal, keep tests readable
+# ---------------------------------------------------------------------------
+
+
+def _make_response(formatted: str | None, available: bool = True):
+    resp = MagicMock()
+    resp.available = available
+    resp.formatted_context = formatted
+    return resp
+
+
+def _fake_sdk(
+    formatted: str | None = "User prefers concise replies.", available: bool = True
+):
+    sdk = MagicMock()
+    sdk.conversation.context.get_context_for_prompt = AsyncMock(
+        return_value=_make_response(formatted, available)
+    )
+    return sdk
+
+
+# ---------------------------------------------------------------------------
+# Construction validation
+# ---------------------------------------------------------------------------
+
+
+class TestValidation:
+    def test_requires_sdk(self):
+        with pytest.raises(ValueError, match="non-None sdk"):
+            synap_st_instructions(None, "conv_abc")  # type: ignore[arg-type]
+
+    def test_requires_nonempty_conversation_id(self):
+        sdk = _fake_sdk()
+        with pytest.raises(ValueError, match="non-empty conversation_id"):
+            synap_st_instructions(sdk, "")
+
+    def test_rejects_whitespace_only_conversation_id(self):
+        sdk = _fake_sdk()
+        with pytest.raises(ValueError, match="non-empty conversation_id"):
+            synap_st_instructions(sdk, "   ")
+
+    def test_rejects_unknown_style(self):
+        sdk = _fake_sdk()
+        with pytest.raises(ValueError, match="unsupported style"):
+            synap_st_instructions(sdk, "conv_abc", style="poetic")
+
+    def test_rejects_invalid_on_error(self):
+        sdk = _fake_sdk()
+        with pytest.raises(ValueError, match="on_error"):
+            synap_st_instructions(sdk, "conv_abc", on_error="ignore")  # type: ignore[arg-type]
+
+    def test_accepts_all_supported_styles(self):
+        sdk = _fake_sdk()
+        for style in ("structured", "narrative", "bullet_points"):
+            # Should NOT raise
+            fn = synap_st_instructions(sdk, "conv_abc", style=style)
+            assert callable(fn), f"should return callable for style={style!r}"
+
+
+# ---------------------------------------------------------------------------
+# Callable contract
+# ---------------------------------------------------------------------------
+
+
+class TestCallableContract:
+    def test_returns_async_callable(self):
+        sdk = _fake_sdk()
+        fn = synap_st_instructions(sdk, "conv_abc")
+        assert callable(fn)
+        assert inspect.iscoroutinefunction(fn), "instructions must be async"
+
+    def test_callable_is_named(self):
+        sdk = _fake_sdk()
+        fn = synap_st_instructions(sdk, "conv_abc")
+        assert fn.__name__ == "synap_st_instructions"
+
+    @pytest.mark.asyncio
+    async def test_accepts_two_positional_args(self):
+        """OpenAI Agents calls instructions(context, agent) — both args must be accepted."""
+        sdk = _fake_sdk(formatted="ctx")
+        fn = synap_st_instructions(sdk, "conv_abc", system="sys")
+        # Should not raise with two MagicMock positional arguments
+        result = await fn(MagicMock(), MagicMock())
+        assert isinstance(result, str)
+
+
+# ---------------------------------------------------------------------------
+# Happy paths — ST present
+# ---------------------------------------------------------------------------
+
+
+class TestHappyPath:
+    @pytest.mark.asyncio
+    async def test_returns_combined_instructions_with_default_preamble(self):
+        sdk = _fake_sdk(formatted="User likes Markdown.")
+        instr = synap_st_instructions(sdk, "conv_abc", system="You are a coding agent.")
+        result = await instr(MagicMock(), MagicMock())
+        assert "<synap_short_term_context>" in result
+        assert "User likes Markdown." in result
+        assert "</synap_short_term_context>" in result
+        assert "You are a coding agent." in result
+        # ST block must appear before user system text
+        assert result.index("User likes Markdown") < result.index("coding agent")
+
+    @pytest.mark.asyncio
+    async def test_passes_conversation_id_and_style_to_sdk(self):
+        sdk = _fake_sdk()
+        instr = synap_st_instructions(
+            sdk, "conv_xyz", style="bullet_points", system="X"
+        )
+        await instr(MagicMock(), MagicMock())
+        sdk.conversation.context.get_context_for_prompt.assert_awaited_once_with(
+            conversation_id="conv_xyz",
+            style="bullet_points",
+        )
+
+    @pytest.mark.asyncio
+    async def test_default_style_is_narrative(self):
+        sdk = _fake_sdk()
+        instr = synap_st_instructions(sdk, "conv_abc", system="X")
+        await instr(MagicMock(), MagicMock())
+        sdk.conversation.context.get_context_for_prompt.assert_awaited_once_with(
+            conversation_id="conv_abc",
+            style="narrative",
+        )
+
+    @pytest.mark.asyncio
+    async def test_custom_preamble_tags(self):
+        sdk = _fake_sdk(formatted="X")
+        instr = synap_st_instructions(
+            sdk,
+            "conv_abc",
+            system="sys",
+            preamble_open="[BEGIN]",
+            preamble_close="[END]",
+        )
+        out = await instr(MagicMock(), MagicMock())
+        assert "[BEGIN]" in out
+        assert "[END]" in out
+        assert "<synap_short_term_context>" not in out
+
+    @pytest.mark.asyncio
+    async def test_no_preamble_raw_concat(self):
+        """When both preamble tags are None, ST and system are joined with double newline."""
+        sdk = _fake_sdk(formatted="raw st")
+        instr = synap_st_instructions(
+            sdk,
+            "conv_abc",
+            system="user sys",
+            preamble_open=None,
+            preamble_close=None,
+        )
+        out = await instr(MagicMock(), MagicMock())
+        assert out == "raw st\n\nuser sys"
+
+    @pytest.mark.asyncio
+    async def test_st_only_no_system(self):
+        """When system is empty, only the ST block (with preamble) is returned."""
+        sdk = _fake_sdk(formatted="context block")
+        instr = synap_st_instructions(sdk, "conv_abc", system="")
+        out = await instr(MagicMock(), MagicMock())
+        assert "context block" in out
+        assert "<synap_short_term_context>" in out
+
+    @pytest.mark.asyncio
+    async def test_structured_style_forwarded(self):
+        sdk = _fake_sdk()
+        instr = synap_st_instructions(sdk, "conv_abc", style="structured")
+        await instr(MagicMock(), MagicMock())
+        sdk.conversation.context.get_context_for_prompt.assert_awaited_once_with(
+            conversation_id="conv_abc",
+            style="structured",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Empty / unavailable ST
+# ---------------------------------------------------------------------------
+
+
+class TestEmptyST:
+    @pytest.mark.asyncio
+    async def test_unavailable_returns_user_system_only(self):
+        sdk = _fake_sdk(formatted=None, available=False)
+        instr = synap_st_instructions(sdk, "conv_abc", system="You are friendly.")
+        out = await instr(MagicMock(), MagicMock())
+        assert out == "You are friendly."
+
+    @pytest.mark.asyncio
+    async def test_unavailable_empty_system_returns_empty_string(self):
+        sdk = _fake_sdk(formatted=None, available=False)
+        instr = synap_st_instructions(sdk, "conv_abc", system="")
+        out = await instr(MagicMock(), MagicMock())
+        assert out == ""
+
+    @pytest.mark.asyncio
+    async def test_none_formatted_context_with_available_true_treated_as_empty(self):
+        """Even if available=True, a None formatted_context yields no ST block."""
+        sdk = _fake_sdk(formatted=None, available=True)
+        instr = synap_st_instructions(sdk, "conv_abc", system="sys")
+        out = await instr(MagicMock(), MagicMock())
+        assert out == "sys"
+        assert "<synap_short_term_context>" not in out
+
+    @pytest.mark.asyncio
+    async def test_empty_string_formatted_context_treated_as_empty(self):
+        sdk = _fake_sdk(formatted="", available=True)
+        instr = synap_st_instructions(sdk, "conv_abc", system="sys")
+        out = await instr(MagicMock(), MagicMock())
+        assert out == "sys"
+
+    @pytest.mark.asyncio
+    async def test_whitespace_only_formatted_context_treated_as_empty(self):
+        sdk = _fake_sdk(formatted="   ", available=True)
+        instr = synap_st_instructions(sdk, "conv_abc", system="sys")
+        out = await instr(MagicMock(), MagicMock())
+        assert out == "sys"
+
+
+# ---------------------------------------------------------------------------
+# Error policies
+# ---------------------------------------------------------------------------
+
+
+class TestErrorPolicies:
+    @pytest.mark.asyncio
+    async def test_fallback_on_sdk_failure_returns_user_system(self):
+        sdk = MagicMock()
+        sdk.conversation.context.get_context_for_prompt = AsyncMock(
+            side_effect=RuntimeError("sdk boom")
+        )
+        instr = synap_st_instructions(
+            sdk, "conv_abc", system="Stay calm.", on_error="fallback"
+        )
+        out = await instr(MagicMock(), MagicMock())
+        assert out == "Stay calm."
+
+    @pytest.mark.asyncio
+    async def test_fallback_empty_system_returns_empty_string(self):
+        sdk = MagicMock()
+        sdk.conversation.context.get_context_for_prompt = AsyncMock(
+            side_effect=RuntimeError("sdk boom")
+        )
+        instr = synap_st_instructions(sdk, "conv_abc", system="", on_error="fallback")
+        out = await instr(MagicMock(), MagicMock())
+        assert out == ""
+
+    @pytest.mark.asyncio
+    async def test_raise_propagates_synap_integration_error(self):
+        sdk = MagicMock()
+        sdk.conversation.context.get_context_for_prompt = AsyncMock(
+            side_effect=RuntimeError("sdk boom")
+        )
+        instr = synap_st_instructions(sdk, "conv_abc", system="X", on_error="raise")
+        with pytest.raises(SynapIntegrationError):
+            await instr(MagicMock(), MagicMock())
+
+    @pytest.mark.asyncio
+    async def test_raise_chains_original_cause(self):
+        original = RuntimeError("original sdk error")
+        sdk = MagicMock()
+        sdk.conversation.context.get_context_for_prompt = AsyncMock(
+            side_effect=original
+        )
+        instr = synap_st_instructions(sdk, "conv_abc", system="X", on_error="raise")
+        with pytest.raises(SynapIntegrationError) as exc_info:
+            await instr(MagicMock(), MagicMock())
+        assert exc_info.value.__cause__ is original
+
+    @pytest.mark.asyncio
+    async def test_synap_integration_error_passthrough_on_raise(self):
+        """A SynapIntegrationError raised by the SDK should propagate without double-wrapping."""
+        sdk = MagicMock()
+        original = SynapIntegrationError("op", "direct error")
+        sdk.conversation.context.get_context_for_prompt = AsyncMock(
+            side_effect=original
+        )
+        instr = synap_st_instructions(sdk, "conv_abc", system="X", on_error="raise")
+        with pytest.raises(SynapIntegrationError) as exc_info:
+            await instr(MagicMock(), MagicMock())
+        # Should be exactly the original instance (not a new wrapper)
+        assert exc_info.value is original
+
+
+# ---------------------------------------------------------------------------
+# failing_sdk harness fixture
+# ---------------------------------------------------------------------------
+
+
+class TestFailingSdkHarness:
+    @pytest.mark.asyncio
+    async def test_fallback_with_failing_sdk(self, failing_sdk):
+        """failing_sdk triggers fallback; system text is returned unmodified."""
+        instr = synap_st_instructions(
+            failing_sdk, "conv_abc", system="fallback text", on_error="fallback"
+        )
+        out = await instr(MagicMock(), MagicMock())
+        assert out == "fallback text"
+
+    @pytest.mark.asyncio
+    async def test_raise_with_failing_sdk_surfaces_error(self, failing_sdk):
+        """failing_sdk with on_error='raise' must propagate as SynapIntegrationError."""
+        instr = synap_st_instructions(
+            failing_sdk, "conv_abc", system="X", on_error="raise"
+        )
+        with pytest.raises(SynapIntegrationError):
+            await instr(MagicMock(), MagicMock())
+
+
+# ---------------------------------------------------------------------------
+# mock_sdk harness fixture
+# ---------------------------------------------------------------------------
+
+
+class TestMockSdkHarness:
+    @pytest.mark.asyncio
+    async def test_mock_sdk_happy_path(self, mock_sdk):
+        """mock_sdk pre-wires get_context_for_prompt → returns a combined instructions string."""
+        instr = synap_st_instructions(
+            mock_sdk, "conv_abc", system="Agent system prompt."
+        )
+        out = await instr(MagicMock(), MagicMock())
+        assert isinstance(out, str)
+        # Combined output contains ST and user system text
+        assert "Agent system prompt." in out
+
+
+# ---------------------------------------------------------------------------
+# Public surface
+# ---------------------------------------------------------------------------
+
+
+class TestPublicSurface:
+    def test_module_exports_synap_st_instructions(self):
+        import synap_dspy
+
+        assert hasattr(synap_dspy, "synap_st_instructions")
+        assert "synap_st_instructions" in synap_dspy.__all__
+
+    def test_create_search_tool_exported(self):
+        import synap_dspy
+
+        assert hasattr(synap_dspy, "create_search_tool")
+        assert "create_search_tool" in synap_dspy.__all__
+
+    def test_create_store_tool_exported(self):
+        import synap_dspy
+
+        assert hasattr(synap_dspy, "create_store_tool")
+        assert "create_store_tool" in synap_dspy.__all__

--- a/packages/integrations/synap-dspy/tests/test_tools.py
+++ b/packages/integrations/synap-dspy/tests/test_tools.py
@@ -1,0 +1,324 @@
+"""Tests for synap_dspy.tools — create_search_tool / create_store_tool.
+
+Documented error-handling contract (from tools.py / wrap_sdk_errors_async):
+- Both factory functions validate sdk != None and user_id != "".
+- The returned async callables wrap SDK errors as SynapIntegrationError.
+- Callers (agent frameworks / test harnesses) decide how to handle the error.
+
+Covers:
+- Construction validation: sdk=None, empty user_id for both factories
+- search_memory happy paths: result forwarding, kwargs forwarded to sdk.fetch,
+  None/empty formatted_context fallback sentinel, conversation_id threading,
+  customer_id threading
+- store_memory happy paths: ingestion_id in return, kwargs forwarded to
+  sdk.memories.create, customer_id pass-through
+- Failure paths: SynapIntegrationError raised on SDK failure (both tools)
+- failing_sdk harness fixture
+- Public surface exports
+"""
+
+from __future__ import annotations
+
+import inspect
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from synap_dspy.tools import create_search_tool, create_store_tool
+from synap_integrations_common import SynapIntegrationError
+
+
+# ---------------------------------------------------------------------------
+# Local helper: minimal SDK mock (unit-level, independent of shared harness)
+# ---------------------------------------------------------------------------
+
+
+def _sdk(fetch_return=None, create_return=None):
+    sdk = MagicMock()
+    sdk.fetch = AsyncMock(
+        return_value=fetch_return or MagicMock(formatted_context="ctx")
+    )
+    sdk.memories = MagicMock()
+    sdk.memories.create = AsyncMock(
+        return_value=create_return or MagicMock(ingestion_id="ing-001")
+    )
+    return sdk
+
+
+# ---------------------------------------------------------------------------
+# Public surface
+# ---------------------------------------------------------------------------
+
+
+def test_package_exports_create_search_tool():
+    from synap_dspy import create_search_tool
+
+    assert create_search_tool is not None
+
+
+def test_package_exports_create_store_tool():
+    from synap_dspy import create_store_tool
+
+    assert create_store_tool is not None
+
+
+# ---------------------------------------------------------------------------
+# create_search_tool — construction validation
+# ---------------------------------------------------------------------------
+
+
+class TestCreateSearchToolValidation:
+    def test_raises_on_none_sdk(self):
+        with pytest.raises(ValueError, match="non-None sdk"):
+            create_search_tool(None, user_id="u1")  # type: ignore[arg-type]
+
+    def test_raises_on_empty_user_id(self):
+        sdk = _sdk()
+        with pytest.raises(ValueError, match="non-empty user_id"):
+            create_search_tool(sdk, user_id="")
+
+    def test_returns_async_callable(self):
+        sdk = _sdk()
+        fn = create_search_tool(sdk, user_id="u1")
+        assert callable(fn)
+        assert inspect.iscoroutinefunction(fn), "search_memory must be async"
+
+
+# ---------------------------------------------------------------------------
+# create_search_tool — happy paths
+# ---------------------------------------------------------------------------
+
+
+class TestSearchToolHappyPath:
+    @pytest.mark.asyncio
+    async def test_returns_formatted_context(self):
+        sdk = _sdk(fetch_return=MagicMock(formatted_context="User likes tea"))
+        search = create_search_tool(sdk, user_id="u1")
+        result = await search(query="tea")
+        assert result == "User likes tea"
+
+    @pytest.mark.asyncio
+    async def test_forwards_query_as_list(self):
+        sdk = _sdk()
+        search = create_search_tool(sdk, user_id="u1")
+        await search(query="coffee preferences")
+        sdk.fetch.assert_awaited_once()
+        assert sdk.fetch.call_args.kwargs["search_query"] == ["coffee preferences"]
+
+    @pytest.mark.asyncio
+    async def test_forwards_user_id(self):
+        sdk = _sdk()
+        search = create_search_tool(sdk, user_id="user-42")
+        await search(query="q")
+        assert sdk.fetch.call_args.kwargs["user_id"] == "user-42"
+
+    @pytest.mark.asyncio
+    async def test_mode_is_accurate(self):
+        sdk = _sdk()
+        search = create_search_tool(sdk, user_id="u1")
+        await search(query="q")
+        assert sdk.fetch.call_args.kwargs["mode"] == "accurate"
+
+    @pytest.mark.asyncio
+    async def test_include_conversation_context_is_false(self):
+        sdk = _sdk()
+        search = create_search_tool(sdk, user_id="u1")
+        await search(query="q")
+        assert sdk.fetch.call_args.kwargs["include_conversation_context"] is False
+
+    @pytest.mark.asyncio
+    async def test_none_formatted_context_returns_sentinel(self):
+        sdk = _sdk(fetch_return=MagicMock(formatted_context=None))
+        search = create_search_tool(sdk, user_id="u1")
+        result = await search(query="unknown")
+        assert result == "No relevant memories found."
+
+    @pytest.mark.asyncio
+    async def test_empty_string_formatted_context_returns_sentinel(self):
+        sdk = _sdk(fetch_return=MagicMock(formatted_context=""))
+        search = create_search_tool(sdk, user_id="u1")
+        result = await search(query="unknown")
+        assert result == "No relevant memories found."
+
+    @pytest.mark.asyncio
+    async def test_conversation_id_forwarded_when_provided(self):
+        sdk = _sdk()
+        search = create_search_tool(sdk, user_id="u1", conversation_id="conv-99")
+        await search(query="q")
+        assert sdk.fetch.call_args.kwargs["conversation_id"] == "conv-99"
+
+    @pytest.mark.asyncio
+    async def test_conversation_id_none_when_not_provided(self):
+        sdk = _sdk()
+        search = create_search_tool(sdk, user_id="u1")
+        await search(query="q")
+        # None or not present — depends on implementation; either is acceptable
+        kwargs = sdk.fetch.call_args.kwargs
+        assert kwargs.get("conversation_id") is None
+
+    @pytest.mark.asyncio
+    async def test_customer_id_forwarded(self):
+        sdk = _sdk()
+        search = create_search_tool(sdk, user_id="u1", customer_id="cust-7")
+        await search(query="q")
+        kwargs = sdk.fetch.call_args.kwargs
+        # customer_id='' maps to None internally; non-empty is forwarded as-is
+        assert kwargs.get("customer_id") == "cust-7"
+
+    @pytest.mark.asyncio
+    async def test_empty_customer_id_coerced_to_none(self):
+        """Empty customer_id is coerced to None before sdk.fetch per product code."""
+        sdk = _sdk()
+        search = create_search_tool(sdk, user_id="u1", customer_id="")
+        await search(query="q")
+        kwargs = sdk.fetch.call_args.kwargs
+        assert kwargs.get("customer_id") is None
+
+
+# ---------------------------------------------------------------------------
+# create_search_tool — failure paths
+# ---------------------------------------------------------------------------
+
+
+class TestSearchToolFailurePath:
+    @pytest.mark.asyncio
+    async def test_raises_synap_integration_error_on_sdk_failure(self):
+        sdk = _sdk()
+        sdk.fetch = AsyncMock(side_effect=RuntimeError("sdk boom"))
+        search = create_search_tool(sdk, user_id="u1")
+        with pytest.raises(SynapIntegrationError):
+            await search(query="any query")
+
+    @pytest.mark.asyncio
+    async def test_synap_integration_error_chains_original_cause(self):
+        original = RuntimeError("original sdk error")
+        sdk = _sdk()
+        sdk.fetch = AsyncMock(side_effect=original)
+        search = create_search_tool(sdk, user_id="u1")
+        with pytest.raises(SynapIntegrationError) as exc_info:
+            await search(query="q")
+        assert exc_info.value.__cause__ is original
+
+    @pytest.mark.asyncio
+    async def test_failing_sdk_search_raises(self, failing_sdk):
+        """Shared failing_sdk fixture — get_context_for_prompt raises RuntimeError."""
+        # failing_sdk wires sdk.fetch to raise; so create_search_tool must propagate
+        search = create_search_tool(failing_sdk, user_id="u1")
+        with pytest.raises(SynapIntegrationError):
+            await search(query="anything")
+
+
+# ---------------------------------------------------------------------------
+# create_store_tool — construction validation
+# ---------------------------------------------------------------------------
+
+
+class TestCreateStoreToolValidation:
+    def test_raises_on_none_sdk(self):
+        with pytest.raises(ValueError, match="non-None sdk"):
+            create_store_tool(None, user_id="u1")  # type: ignore[arg-type]
+
+    def test_raises_on_empty_user_id(self):
+        sdk = _sdk()
+        with pytest.raises(ValueError, match="non-empty user_id"):
+            create_store_tool(sdk, user_id="")
+
+    def test_returns_async_callable(self):
+        sdk = _sdk()
+        fn = create_store_tool(sdk, user_id="u1")
+        assert callable(fn)
+        assert inspect.iscoroutinefunction(fn), "store_memory must be async"
+
+
+# ---------------------------------------------------------------------------
+# create_store_tool — happy paths
+# ---------------------------------------------------------------------------
+
+
+class TestStoreToolHappyPath:
+    @pytest.mark.asyncio
+    async def test_returns_string_with_ingestion_id(self):
+        sdk = _sdk(create_return=MagicMock(ingestion_id="ing-123"))
+        store = create_store_tool(sdk, user_id="u1")
+        result = await store(content="User prefers dark mode")
+        assert "ing-123" in result
+
+    @pytest.mark.asyncio
+    async def test_returns_string(self):
+        sdk = _sdk()
+        store = create_store_tool(sdk, user_id="u1")
+        result = await store(content="some content")
+        assert isinstance(result, str)
+
+    @pytest.mark.asyncio
+    async def test_forwards_document_to_memories_create(self):
+        sdk = _sdk()
+        store = create_store_tool(sdk, user_id="u1")
+        await store(content="User prefers dark mode")
+        sdk.memories.create.assert_awaited_once()
+        kwargs = sdk.memories.create.call_args.kwargs
+        assert kwargs["document"] == "User prefers dark mode"
+
+    @pytest.mark.asyncio
+    async def test_forwards_user_id_to_memories_create(self):
+        sdk = _sdk()
+        store = create_store_tool(sdk, user_id="user-99")
+        await store(content="some info")
+        kwargs = sdk.memories.create.call_args.kwargs
+        assert kwargs["user_id"] == "user-99"
+
+    @pytest.mark.asyncio
+    async def test_forwards_customer_id_to_memories_create(self):
+        sdk = _sdk()
+        store = create_store_tool(sdk, user_id="u1", customer_id="cust-42")
+        await store(content="info")
+        kwargs = sdk.memories.create.call_args.kwargs
+        assert kwargs["customer_id"] == "cust-42"
+
+    @pytest.mark.asyncio
+    async def test_empty_customer_id_forwarded_as_empty_string(self):
+        """Default customer_id='' is passed through to memories.create unchanged."""
+        sdk = _sdk()
+        store = create_store_tool(sdk, user_id="u1")
+        await store(content="info")
+        kwargs = sdk.memories.create.call_args.kwargs
+        assert kwargs["customer_id"] == ""
+
+    @pytest.mark.asyncio
+    async def test_mock_sdk_store_happy_path(self, mock_sdk):
+        """Shared mock_sdk harness: memories.create pre-wired to return ingestion_id=ing-001."""
+        store = create_store_tool(mock_sdk, user_id="u1")
+        result = await store(content="remember this")
+        assert "ing-001" in result
+
+
+# ---------------------------------------------------------------------------
+# create_store_tool — failure paths
+# ---------------------------------------------------------------------------
+
+
+class TestStoreToolFailurePath:
+    @pytest.mark.asyncio
+    async def test_raises_synap_integration_error_on_sdk_failure(self):
+        sdk = _sdk()
+        sdk.memories.create = AsyncMock(side_effect=RuntimeError("sdk boom"))
+        store = create_store_tool(sdk, user_id="u1")
+        with pytest.raises(SynapIntegrationError):
+            await store(content="content to store")
+
+    @pytest.mark.asyncio
+    async def test_synap_integration_error_chains_original_cause(self):
+        original = RuntimeError("original error")
+        sdk = _sdk()
+        sdk.memories.create = AsyncMock(side_effect=original)
+        store = create_store_tool(sdk, user_id="u1")
+        with pytest.raises(SynapIntegrationError) as exc_info:
+            await store(content="content")
+        assert exc_info.value.__cause__ is original
+
+    @pytest.mark.asyncio
+    async def test_failing_sdk_store_raises(self, failing_sdk):
+        """Shared failing_sdk fixture — sdk.memories.create raises RuntimeError."""
+        store = create_store_tool(failing_sdk, user_id="u1")
+        with pytest.raises(SynapIntegrationError):
+            await store(content="anything")

--- a/packages/integrations/synap-marvin/README.md
+++ b/packages/integrations/synap-marvin/README.md
@@ -1,0 +1,31 @@
+# Synap + Marvin
+
+Synap memory tools and short-term context helpers for [Marvin](https://pypi.org/).
+
+## Install
+
+```bash
+pip install maximem-synap maximem-synap-marvin
+```
+
+## Usage
+
+```python
+from maximem_synap import MaximemSynapSDK
+from synap_marvin import create_search_tool, create_store_tool, synap_st_instructions
+
+sdk = MaximemSynapSDK(api_key="your-api-key")
+await sdk.initialize()
+
+search = create_search_tool(sdk, user_id="alice", conversation_id="conv-1")
+store = create_store_tool(sdk, user_id="alice")
+
+# Marvin agent with synap_st_instructions hook
+instructions = synap_st_instructions(
+    sdk,
+    conversation_id="conv-1",
+    system="You are a helpful assistant.",
+)
+```
+
+See the root repo README for scoping (`user_id`, `customer_id`, `conversation_id`) and benchmark context.

--- a/packages/integrations/synap-marvin/pyproject.toml
+++ b/packages/integrations/synap-marvin/pyproject.toml
@@ -1,0 +1,23 @@
+[build-system]
+requires = ["setuptools>=61.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "maximem-synap-marvin"
+version = "0.2.0"
+description = "Synap memory integration for Marvin"
+readme = "README.md"
+requires-python = ">=3.11"
+license = "Apache-2.0"
+dependencies = ["maximem-synap>=0.2.0", "maximem-synap-integrations-common>=0.1.0", "marvin>=2.0"]
+
+[project.optional-dependencies]
+dev = ["pytest>=7.0", "pytest-asyncio>=0.21"]
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["synap_marvin*"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+asyncio_mode = "auto"

--- a/packages/integrations/synap-marvin/synap_marvin/__init__.py
+++ b/packages/integrations/synap-marvin/synap_marvin/__init__.py
@@ -1,0 +1,10 @@
+"""Synap memory integration for Marvin."""
+
+from synap_marvin.short_term import synap_st_instructions
+from synap_marvin.tools import create_search_tool, create_store_tool
+
+__all__ = [
+    "create_search_tool",
+    "create_store_tool",
+    "synap_st_instructions",
+]

--- a/packages/integrations/synap-marvin/synap_marvin/short_term.py
+++ b/packages/integrations/synap-marvin/synap_marvin/short_term.py
@@ -1,0 +1,163 @@
+"""Synap short-term context for Marvin.
+
+Mirrors the LangGraph template: a single thin wrapper around
+``sdk.conversation.context.get_context_for_prompt``. Quality contract is
+identical to the LangGraph adapter (see synap_langgraph.short_term).
+
+Marvin accepts ``Agent(instructions=...)`` where ``instructions``
+can be a string OR an async callable receiving ``(context, agent)`` and
+returning a string. :func:`synap_st_instructions` returns the second
+form: each agent step calls into the SDK helper (cache-first), prepends
+the ST block above your own system text inside the configured preamble
+tags, and returns the combined instructions string.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Awaitable, Callable, Literal, Optional
+
+from maximem_synap import MaximemSynapSDK
+from synap_integrations_common import (
+    SynapIntegrationError,
+    wrap_sdk_errors_async,
+)
+
+logger = logging.getLogger(__name__)
+
+_SUPPORTED_STYLES = ("structured", "narrative", "bullet_points")
+_DEFAULT_OPEN = "<synap_short_term_context>"
+_DEFAULT_CLOSE = "</synap_short_term_context>"
+
+_OnError = Literal["fallback", "raise"]
+
+
+def _validate_args(
+    sdk: Optional[MaximemSynapSDK],
+    conversation_id: str,
+    style: str,
+    on_error: str,
+    site: str,
+) -> None:
+    if sdk is None:
+        raise ValueError(f"{site} requires a non-None sdk")
+    if not conversation_id or not str(conversation_id).strip():
+        raise ValueError(f"{site} requires a non-empty conversation_id")
+    if style not in _SUPPORTED_STYLES:
+        raise ValueError(
+            f"{site}: unsupported style={style!r}; expected one of {_SUPPORTED_STYLES}"
+        )
+    if on_error not in ("fallback", "raise"):
+        raise ValueError(
+            f"{site}: on_error must be 'fallback' or 'raise', got {on_error!r}"
+        )
+
+
+async def _fetch_st_block(
+    sdk: MaximemSynapSDK,
+    conversation_id: str,
+    style: str,
+    on_error: _OnError,
+    site: str,
+) -> str:
+    try:
+        async with wrap_sdk_errors_async(
+            site,
+            logger,
+            conversation_id=conversation_id,
+            style=style,
+        ):
+            response = await sdk.conversation.context.get_context_for_prompt(
+                conversation_id=conversation_id,
+                style=style,
+            )
+    except SynapIntegrationError:
+        if on_error == "raise":
+            raise
+        return ""
+    if not getattr(response, "available", False):
+        return ""
+    formatted = getattr(response, "formatted_context", None)
+    return (formatted or "").strip()
+
+
+def _compose(
+    st_block: str,
+    user_system: str,
+    preamble_open: Optional[str],
+    preamble_close: Optional[str],
+) -> str:
+    parts = []
+    st_block = (st_block or "").strip()
+    user_system = (user_system or "").strip()
+    if st_block:
+        if preamble_open and preamble_close:
+            parts.append(f"{preamble_open}\n{st_block}\n{preamble_close}")
+        else:
+            parts.append(st_block)
+    if user_system:
+        parts.append(user_system)
+    return "\n\n".join(parts)
+
+
+def synap_st_instructions(
+    sdk: MaximemSynapSDK,
+    conversation_id: str,
+    *,
+    system: str = "",
+    style: str = "narrative",
+    preamble_open: Optional[str] = _DEFAULT_OPEN,
+    preamble_close: Optional[str] = _DEFAULT_CLOSE,
+    on_error: _OnError = "fallback",
+) -> Callable[[Any, Any], Awaitable[str]]:
+    """Return an async ``instructions`` callable for Marvin.
+
+    The callable matches Marvin' expected signature
+    ``async (context, agent) -> str``. Both arguments are ignored — we
+    use the explicitly-bound ``conversation_id`` rather than inferring
+    from any framework-internal session.
+
+    Args:
+        sdk: Initialised :class:`MaximemSynapSDK`.
+        conversation_id: Synap conversation ID. **Required.**
+        system: Your own agent instructions; ST is prepended above.
+        style: One of ``"structured" | "narrative" | "bullet_points"``.
+        preamble_open / preamble_close: Wrapping tags; pass ``None`` for
+            both to drop the tags.
+        on_error: ``"fallback"`` (default) returns bare ``system`` on
+            SDK failure; ``"raise"`` propagates :class:`SynapIntegrationError`.
+
+    Example::
+
+        # from Marvin import Agent  # example
+        from maximem_synap import MaximemSynapSDK
+        from synap_marvin import synap_st_instructions
+
+        sdk = MaximemSynapSDK(api_key="sk-...")
+        agent = Agent(
+            name="support",
+            instructions=synap_st_instructions(
+                sdk,
+                conversation_id="conv_abc",
+                system="You are a polite support agent.",
+            ),
+            tools=[...],
+        )
+    """
+    _validate_args(sdk, conversation_id, style, on_error, "synap_st_instructions")
+
+    async def _instructions(context: Any, agent: Any) -> str:  # noqa: ARG001 — framework signature
+        st_block = await _fetch_st_block(
+            sdk,
+            conversation_id,
+            style,
+            on_error,
+            site="synap_marvin.synap_st_instructions",
+        )
+        return _compose(st_block, system, preamble_open, preamble_close)
+
+    _instructions.__name__ = "synap_st_instructions"
+    return _instructions
+
+
+__all__ = ["synap_st_instructions"]

--- a/packages/integrations/synap-marvin/synap_marvin/tools.py
+++ b/packages/integrations/synap-marvin/synap_marvin/tools.py
@@ -1,0 +1,79 @@
+"""Synap tools for Marvin.
+
+Provides memory search/store callables for Marvin agents.
+SDK failures are wrapped in :class:`SynapIntegrationError`.
+"""
+
+import logging
+from typing import Optional
+
+from maximem_synap import MaximemSynapSDK
+from synap_integrations_common import wrap_sdk_errors_async
+
+logger = logging.getLogger(__name__)
+
+
+def create_search_tool(
+    sdk: MaximemSynapSDK,
+    user_id: str,
+    customer_id: str = "",
+    conversation_id: Optional[str] = None,
+):
+    """Create a memory search callable for Marvin.
+
+    Example::
+
+        search_fn = create_search_tool(sdk, user_id="u1")
+        # Wire into your Marvin agent: @marvin.tool async def search_memory(...)
+    """
+    if sdk is None:
+        raise ValueError("create_search_tool requires a non-None sdk")
+    if not user_id:
+        raise ValueError("create_search_tool requires a non-empty user_id")
+
+    async def search_memory(query: str) -> str:
+        """Search the user's memory for relevant context."""
+        async with wrap_sdk_errors_async(
+            "marvin.search_memory",
+            logger,
+            user_id=user_id,
+        ):
+            response = await sdk.fetch(
+                conversation_id=conversation_id,
+                user_id=user_id,
+                customer_id=customer_id or None,
+                search_query=[query],
+                mode="accurate",
+                include_conversation_context=False,
+            )
+        return response.formatted_context or "No relevant memories found."
+
+    return search_memory
+
+
+def create_store_tool(
+    sdk: MaximemSynapSDK,
+    user_id: str,
+    customer_id: str = "",
+):
+    """Create a memory store callable for Marvin."""
+    if sdk is None:
+        raise ValueError("create_store_tool requires a non-None sdk")
+    if not user_id:
+        raise ValueError("create_store_tool requires a non-empty user_id")
+
+    async def store_memory(content: str) -> str:
+        """Store important information about the user for future reference."""
+        async with wrap_sdk_errors_async(
+            "marvin.store_memory",
+            logger,
+            user_id=user_id,
+        ):
+            result = await sdk.memories.create(
+                document=content,
+                user_id=user_id,
+                customer_id=customer_id,
+            )
+        return f"Memory stored (ingestion_id: {result.ingestion_id})"
+
+    return store_memory

--- a/packages/integrations/synap-marvin/tests/conftest.py
+++ b/packages/integrations/synap-marvin/tests/conftest.py
@@ -1,0 +1,26 @@
+"""Pytest conftest for synap-openai-agents tests.
+
+Re-exports fixtures and factories from the shared harness so every test file
+can rely on a single, canonical source of truth.
+"""
+
+import sys
+import os
+
+# Ensure local packages are importable when running from repo root.
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../synap/sdk/python"))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(
+    0, os.path.join(os.path.dirname(__file__), "../../synap-integrations-common")
+)
+
+from synap_integrations_common.testing import (  # noqa: F401
+    mock_sdk,
+    failing_sdk,
+    make_fact,
+    make_preference,
+    make_episode,
+    make_emotion,
+    make_temporal_event,
+    make_unified_response,
+)

--- a/packages/integrations/synap-marvin/tests/test_short_term.py
+++ b/packages/integrations/synap-marvin/tests/test_short_term.py
@@ -1,0 +1,376 @@
+"""Tests for synap_marvin.short_term — synap_st_instructions.
+
+Covers:
+- Construction validation (sdk=None, empty/whitespace conversation_id, unknown style,
+  invalid on_error)
+- Happy paths: ST block present, preamble wrapping, style forwarding, all 3 styles accepted
+- Empty-ST safety: unavailable flag, None formatted_context, empty string
+- Error policies: fallback (on_error="fallback") returns bare system, raise propagates
+  SynapIntegrationError
+- Callable contract: returned value is an async callable accepting (context, agent)
+- Harness: failing_sdk fixture
+- Public surface: __all__ exports
+"""
+
+from __future__ import annotations
+
+import inspect
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from synap_marvin.short_term import synap_st_instructions
+from synap_integrations_common import SynapIntegrationError
+
+
+# ---------------------------------------------------------------------------
+# Local helpers — minimal, keep tests readable
+# ---------------------------------------------------------------------------
+
+
+def _make_response(formatted: str | None, available: bool = True):
+    resp = MagicMock()
+    resp.available = available
+    resp.formatted_context = formatted
+    return resp
+
+
+def _fake_sdk(
+    formatted: str | None = "User prefers concise replies.", available: bool = True
+):
+    sdk = MagicMock()
+    sdk.conversation.context.get_context_for_prompt = AsyncMock(
+        return_value=_make_response(formatted, available)
+    )
+    return sdk
+
+
+# ---------------------------------------------------------------------------
+# Construction validation
+# ---------------------------------------------------------------------------
+
+
+class TestValidation:
+    def test_requires_sdk(self):
+        with pytest.raises(ValueError, match="non-None sdk"):
+            synap_st_instructions(None, "conv_abc")  # type: ignore[arg-type]
+
+    def test_requires_nonempty_conversation_id(self):
+        sdk = _fake_sdk()
+        with pytest.raises(ValueError, match="non-empty conversation_id"):
+            synap_st_instructions(sdk, "")
+
+    def test_rejects_whitespace_only_conversation_id(self):
+        sdk = _fake_sdk()
+        with pytest.raises(ValueError, match="non-empty conversation_id"):
+            synap_st_instructions(sdk, "   ")
+
+    def test_rejects_unknown_style(self):
+        sdk = _fake_sdk()
+        with pytest.raises(ValueError, match="unsupported style"):
+            synap_st_instructions(sdk, "conv_abc", style="poetic")
+
+    def test_rejects_invalid_on_error(self):
+        sdk = _fake_sdk()
+        with pytest.raises(ValueError, match="on_error"):
+            synap_st_instructions(sdk, "conv_abc", on_error="ignore")  # type: ignore[arg-type]
+
+    def test_accepts_all_supported_styles(self):
+        sdk = _fake_sdk()
+        for style in ("structured", "narrative", "bullet_points"):
+            # Should NOT raise
+            fn = synap_st_instructions(sdk, "conv_abc", style=style)
+            assert callable(fn), f"should return callable for style={style!r}"
+
+
+# ---------------------------------------------------------------------------
+# Callable contract
+# ---------------------------------------------------------------------------
+
+
+class TestCallableContract:
+    def test_returns_async_callable(self):
+        sdk = _fake_sdk()
+        fn = synap_st_instructions(sdk, "conv_abc")
+        assert callable(fn)
+        assert inspect.iscoroutinefunction(fn), "instructions must be async"
+
+    def test_callable_is_named(self):
+        sdk = _fake_sdk()
+        fn = synap_st_instructions(sdk, "conv_abc")
+        assert fn.__name__ == "synap_st_instructions"
+
+    @pytest.mark.asyncio
+    async def test_accepts_two_positional_args(self):
+        """OpenAI Agents calls instructions(context, agent) — both args must be accepted."""
+        sdk = _fake_sdk(formatted="ctx")
+        fn = synap_st_instructions(sdk, "conv_abc", system="sys")
+        # Should not raise with two MagicMock positional arguments
+        result = await fn(MagicMock(), MagicMock())
+        assert isinstance(result, str)
+
+
+# ---------------------------------------------------------------------------
+# Happy paths — ST present
+# ---------------------------------------------------------------------------
+
+
+class TestHappyPath:
+    @pytest.mark.asyncio
+    async def test_returns_combined_instructions_with_default_preamble(self):
+        sdk = _fake_sdk(formatted="User likes Markdown.")
+        instr = synap_st_instructions(sdk, "conv_abc", system="You are a coding agent.")
+        result = await instr(MagicMock(), MagicMock())
+        assert "<synap_short_term_context>" in result
+        assert "User likes Markdown." in result
+        assert "</synap_short_term_context>" in result
+        assert "You are a coding agent." in result
+        # ST block must appear before user system text
+        assert result.index("User likes Markdown") < result.index("coding agent")
+
+    @pytest.mark.asyncio
+    async def test_passes_conversation_id_and_style_to_sdk(self):
+        sdk = _fake_sdk()
+        instr = synap_st_instructions(
+            sdk, "conv_xyz", style="bullet_points", system="X"
+        )
+        await instr(MagicMock(), MagicMock())
+        sdk.conversation.context.get_context_for_prompt.assert_awaited_once_with(
+            conversation_id="conv_xyz",
+            style="bullet_points",
+        )
+
+    @pytest.mark.asyncio
+    async def test_default_style_is_narrative(self):
+        sdk = _fake_sdk()
+        instr = synap_st_instructions(sdk, "conv_abc", system="X")
+        await instr(MagicMock(), MagicMock())
+        sdk.conversation.context.get_context_for_prompt.assert_awaited_once_with(
+            conversation_id="conv_abc",
+            style="narrative",
+        )
+
+    @pytest.mark.asyncio
+    async def test_custom_preamble_tags(self):
+        sdk = _fake_sdk(formatted="X")
+        instr = synap_st_instructions(
+            sdk,
+            "conv_abc",
+            system="sys",
+            preamble_open="[BEGIN]",
+            preamble_close="[END]",
+        )
+        out = await instr(MagicMock(), MagicMock())
+        assert "[BEGIN]" in out
+        assert "[END]" in out
+        assert "<synap_short_term_context>" not in out
+
+    @pytest.mark.asyncio
+    async def test_no_preamble_raw_concat(self):
+        """When both preamble tags are None, ST and system are joined with double newline."""
+        sdk = _fake_sdk(formatted="raw st")
+        instr = synap_st_instructions(
+            sdk,
+            "conv_abc",
+            system="user sys",
+            preamble_open=None,
+            preamble_close=None,
+        )
+        out = await instr(MagicMock(), MagicMock())
+        assert out == "raw st\n\nuser sys"
+
+    @pytest.mark.asyncio
+    async def test_st_only_no_system(self):
+        """When system is empty, only the ST block (with preamble) is returned."""
+        sdk = _fake_sdk(formatted="context block")
+        instr = synap_st_instructions(sdk, "conv_abc", system="")
+        out = await instr(MagicMock(), MagicMock())
+        assert "context block" in out
+        assert "<synap_short_term_context>" in out
+
+    @pytest.mark.asyncio
+    async def test_structured_style_forwarded(self):
+        sdk = _fake_sdk()
+        instr = synap_st_instructions(sdk, "conv_abc", style="structured")
+        await instr(MagicMock(), MagicMock())
+        sdk.conversation.context.get_context_for_prompt.assert_awaited_once_with(
+            conversation_id="conv_abc",
+            style="structured",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Empty / unavailable ST
+# ---------------------------------------------------------------------------
+
+
+class TestEmptyST:
+    @pytest.mark.asyncio
+    async def test_unavailable_returns_user_system_only(self):
+        sdk = _fake_sdk(formatted=None, available=False)
+        instr = synap_st_instructions(sdk, "conv_abc", system="You are friendly.")
+        out = await instr(MagicMock(), MagicMock())
+        assert out == "You are friendly."
+
+    @pytest.mark.asyncio
+    async def test_unavailable_empty_system_returns_empty_string(self):
+        sdk = _fake_sdk(formatted=None, available=False)
+        instr = synap_st_instructions(sdk, "conv_abc", system="")
+        out = await instr(MagicMock(), MagicMock())
+        assert out == ""
+
+    @pytest.mark.asyncio
+    async def test_none_formatted_context_with_available_true_treated_as_empty(self):
+        """Even if available=True, a None formatted_context yields no ST block."""
+        sdk = _fake_sdk(formatted=None, available=True)
+        instr = synap_st_instructions(sdk, "conv_abc", system="sys")
+        out = await instr(MagicMock(), MagicMock())
+        assert out == "sys"
+        assert "<synap_short_term_context>" not in out
+
+    @pytest.mark.asyncio
+    async def test_empty_string_formatted_context_treated_as_empty(self):
+        sdk = _fake_sdk(formatted="", available=True)
+        instr = synap_st_instructions(sdk, "conv_abc", system="sys")
+        out = await instr(MagicMock(), MagicMock())
+        assert out == "sys"
+
+    @pytest.mark.asyncio
+    async def test_whitespace_only_formatted_context_treated_as_empty(self):
+        sdk = _fake_sdk(formatted="   ", available=True)
+        instr = synap_st_instructions(sdk, "conv_abc", system="sys")
+        out = await instr(MagicMock(), MagicMock())
+        assert out == "sys"
+
+
+# ---------------------------------------------------------------------------
+# Error policies
+# ---------------------------------------------------------------------------
+
+
+class TestErrorPolicies:
+    @pytest.mark.asyncio
+    async def test_fallback_on_sdk_failure_returns_user_system(self):
+        sdk = MagicMock()
+        sdk.conversation.context.get_context_for_prompt = AsyncMock(
+            side_effect=RuntimeError("sdk boom")
+        )
+        instr = synap_st_instructions(
+            sdk, "conv_abc", system="Stay calm.", on_error="fallback"
+        )
+        out = await instr(MagicMock(), MagicMock())
+        assert out == "Stay calm."
+
+    @pytest.mark.asyncio
+    async def test_fallback_empty_system_returns_empty_string(self):
+        sdk = MagicMock()
+        sdk.conversation.context.get_context_for_prompt = AsyncMock(
+            side_effect=RuntimeError("sdk boom")
+        )
+        instr = synap_st_instructions(sdk, "conv_abc", system="", on_error="fallback")
+        out = await instr(MagicMock(), MagicMock())
+        assert out == ""
+
+    @pytest.mark.asyncio
+    async def test_raise_propagates_synap_integration_error(self):
+        sdk = MagicMock()
+        sdk.conversation.context.get_context_for_prompt = AsyncMock(
+            side_effect=RuntimeError("sdk boom")
+        )
+        instr = synap_st_instructions(sdk, "conv_abc", system="X", on_error="raise")
+        with pytest.raises(SynapIntegrationError):
+            await instr(MagicMock(), MagicMock())
+
+    @pytest.mark.asyncio
+    async def test_raise_chains_original_cause(self):
+        original = RuntimeError("original sdk error")
+        sdk = MagicMock()
+        sdk.conversation.context.get_context_for_prompt = AsyncMock(
+            side_effect=original
+        )
+        instr = synap_st_instructions(sdk, "conv_abc", system="X", on_error="raise")
+        with pytest.raises(SynapIntegrationError) as exc_info:
+            await instr(MagicMock(), MagicMock())
+        assert exc_info.value.__cause__ is original
+
+    @pytest.mark.asyncio
+    async def test_synap_integration_error_passthrough_on_raise(self):
+        """A SynapIntegrationError raised by the SDK should propagate without double-wrapping."""
+        sdk = MagicMock()
+        original = SynapIntegrationError("op", "direct error")
+        sdk.conversation.context.get_context_for_prompt = AsyncMock(
+            side_effect=original
+        )
+        instr = synap_st_instructions(sdk, "conv_abc", system="X", on_error="raise")
+        with pytest.raises(SynapIntegrationError) as exc_info:
+            await instr(MagicMock(), MagicMock())
+        # Should be exactly the original instance (not a new wrapper)
+        assert exc_info.value is original
+
+
+# ---------------------------------------------------------------------------
+# failing_sdk harness fixture
+# ---------------------------------------------------------------------------
+
+
+class TestFailingSdkHarness:
+    @pytest.mark.asyncio
+    async def test_fallback_with_failing_sdk(self, failing_sdk):
+        """failing_sdk triggers fallback; system text is returned unmodified."""
+        instr = synap_st_instructions(
+            failing_sdk, "conv_abc", system="fallback text", on_error="fallback"
+        )
+        out = await instr(MagicMock(), MagicMock())
+        assert out == "fallback text"
+
+    @pytest.mark.asyncio
+    async def test_raise_with_failing_sdk_surfaces_error(self, failing_sdk):
+        """failing_sdk with on_error='raise' must propagate as SynapIntegrationError."""
+        instr = synap_st_instructions(
+            failing_sdk, "conv_abc", system="X", on_error="raise"
+        )
+        with pytest.raises(SynapIntegrationError):
+            await instr(MagicMock(), MagicMock())
+
+
+# ---------------------------------------------------------------------------
+# mock_sdk harness fixture
+# ---------------------------------------------------------------------------
+
+
+class TestMockSdkHarness:
+    @pytest.mark.asyncio
+    async def test_mock_sdk_happy_path(self, mock_sdk):
+        """mock_sdk pre-wires get_context_for_prompt → returns a combined instructions string."""
+        instr = synap_st_instructions(
+            mock_sdk, "conv_abc", system="Agent system prompt."
+        )
+        out = await instr(MagicMock(), MagicMock())
+        assert isinstance(out, str)
+        # Combined output contains ST and user system text
+        assert "Agent system prompt." in out
+
+
+# ---------------------------------------------------------------------------
+# Public surface
+# ---------------------------------------------------------------------------
+
+
+class TestPublicSurface:
+    def test_module_exports_synap_st_instructions(self):
+        import synap_marvin
+
+        assert hasattr(synap_marvin, "synap_st_instructions")
+        assert "synap_st_instructions" in synap_marvin.__all__
+
+    def test_create_search_tool_exported(self):
+        import synap_marvin
+
+        assert hasattr(synap_marvin, "create_search_tool")
+        assert "create_search_tool" in synap_marvin.__all__
+
+    def test_create_store_tool_exported(self):
+        import synap_marvin
+
+        assert hasattr(synap_marvin, "create_store_tool")
+        assert "create_store_tool" in synap_marvin.__all__

--- a/packages/integrations/synap-marvin/tests/test_tools.py
+++ b/packages/integrations/synap-marvin/tests/test_tools.py
@@ -1,0 +1,324 @@
+"""Tests for synap_marvin.tools — create_search_tool / create_store_tool.
+
+Documented error-handling contract (from tools.py / wrap_sdk_errors_async):
+- Both factory functions validate sdk != None and user_id != "".
+- The returned async callables wrap SDK errors as SynapIntegrationError.
+- Callers (agent frameworks / test harnesses) decide how to handle the error.
+
+Covers:
+- Construction validation: sdk=None, empty user_id for both factories
+- search_memory happy paths: result forwarding, kwargs forwarded to sdk.fetch,
+  None/empty formatted_context fallback sentinel, conversation_id threading,
+  customer_id threading
+- store_memory happy paths: ingestion_id in return, kwargs forwarded to
+  sdk.memories.create, customer_id pass-through
+- Failure paths: SynapIntegrationError raised on SDK failure (both tools)
+- failing_sdk harness fixture
+- Public surface exports
+"""
+
+from __future__ import annotations
+
+import inspect
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from synap_marvin.tools import create_search_tool, create_store_tool
+from synap_integrations_common import SynapIntegrationError
+
+
+# ---------------------------------------------------------------------------
+# Local helper: minimal SDK mock (unit-level, independent of shared harness)
+# ---------------------------------------------------------------------------
+
+
+def _sdk(fetch_return=None, create_return=None):
+    sdk = MagicMock()
+    sdk.fetch = AsyncMock(
+        return_value=fetch_return or MagicMock(formatted_context="ctx")
+    )
+    sdk.memories = MagicMock()
+    sdk.memories.create = AsyncMock(
+        return_value=create_return or MagicMock(ingestion_id="ing-001")
+    )
+    return sdk
+
+
+# ---------------------------------------------------------------------------
+# Public surface
+# ---------------------------------------------------------------------------
+
+
+def test_package_exports_create_search_tool():
+    from synap_marvin import create_search_tool
+
+    assert create_search_tool is not None
+
+
+def test_package_exports_create_store_tool():
+    from synap_marvin import create_store_tool
+
+    assert create_store_tool is not None
+
+
+# ---------------------------------------------------------------------------
+# create_search_tool — construction validation
+# ---------------------------------------------------------------------------
+
+
+class TestCreateSearchToolValidation:
+    def test_raises_on_none_sdk(self):
+        with pytest.raises(ValueError, match="non-None sdk"):
+            create_search_tool(None, user_id="u1")  # type: ignore[arg-type]
+
+    def test_raises_on_empty_user_id(self):
+        sdk = _sdk()
+        with pytest.raises(ValueError, match="non-empty user_id"):
+            create_search_tool(sdk, user_id="")
+
+    def test_returns_async_callable(self):
+        sdk = _sdk()
+        fn = create_search_tool(sdk, user_id="u1")
+        assert callable(fn)
+        assert inspect.iscoroutinefunction(fn), "search_memory must be async"
+
+
+# ---------------------------------------------------------------------------
+# create_search_tool — happy paths
+# ---------------------------------------------------------------------------
+
+
+class TestSearchToolHappyPath:
+    @pytest.mark.asyncio
+    async def test_returns_formatted_context(self):
+        sdk = _sdk(fetch_return=MagicMock(formatted_context="User likes tea"))
+        search = create_search_tool(sdk, user_id="u1")
+        result = await search(query="tea")
+        assert result == "User likes tea"
+
+    @pytest.mark.asyncio
+    async def test_forwards_query_as_list(self):
+        sdk = _sdk()
+        search = create_search_tool(sdk, user_id="u1")
+        await search(query="coffee preferences")
+        sdk.fetch.assert_awaited_once()
+        assert sdk.fetch.call_args.kwargs["search_query"] == ["coffee preferences"]
+
+    @pytest.mark.asyncio
+    async def test_forwards_user_id(self):
+        sdk = _sdk()
+        search = create_search_tool(sdk, user_id="user-42")
+        await search(query="q")
+        assert sdk.fetch.call_args.kwargs["user_id"] == "user-42"
+
+    @pytest.mark.asyncio
+    async def test_mode_is_accurate(self):
+        sdk = _sdk()
+        search = create_search_tool(sdk, user_id="u1")
+        await search(query="q")
+        assert sdk.fetch.call_args.kwargs["mode"] == "accurate"
+
+    @pytest.mark.asyncio
+    async def test_include_conversation_context_is_false(self):
+        sdk = _sdk()
+        search = create_search_tool(sdk, user_id="u1")
+        await search(query="q")
+        assert sdk.fetch.call_args.kwargs["include_conversation_context"] is False
+
+    @pytest.mark.asyncio
+    async def test_none_formatted_context_returns_sentinel(self):
+        sdk = _sdk(fetch_return=MagicMock(formatted_context=None))
+        search = create_search_tool(sdk, user_id="u1")
+        result = await search(query="unknown")
+        assert result == "No relevant memories found."
+
+    @pytest.mark.asyncio
+    async def test_empty_string_formatted_context_returns_sentinel(self):
+        sdk = _sdk(fetch_return=MagicMock(formatted_context=""))
+        search = create_search_tool(sdk, user_id="u1")
+        result = await search(query="unknown")
+        assert result == "No relevant memories found."
+
+    @pytest.mark.asyncio
+    async def test_conversation_id_forwarded_when_provided(self):
+        sdk = _sdk()
+        search = create_search_tool(sdk, user_id="u1", conversation_id="conv-99")
+        await search(query="q")
+        assert sdk.fetch.call_args.kwargs["conversation_id"] == "conv-99"
+
+    @pytest.mark.asyncio
+    async def test_conversation_id_none_when_not_provided(self):
+        sdk = _sdk()
+        search = create_search_tool(sdk, user_id="u1")
+        await search(query="q")
+        # None or not present — depends on implementation; either is acceptable
+        kwargs = sdk.fetch.call_args.kwargs
+        assert kwargs.get("conversation_id") is None
+
+    @pytest.mark.asyncio
+    async def test_customer_id_forwarded(self):
+        sdk = _sdk()
+        search = create_search_tool(sdk, user_id="u1", customer_id="cust-7")
+        await search(query="q")
+        kwargs = sdk.fetch.call_args.kwargs
+        # customer_id='' maps to None internally; non-empty is forwarded as-is
+        assert kwargs.get("customer_id") == "cust-7"
+
+    @pytest.mark.asyncio
+    async def test_empty_customer_id_coerced_to_none(self):
+        """Empty customer_id is coerced to None before sdk.fetch per product code."""
+        sdk = _sdk()
+        search = create_search_tool(sdk, user_id="u1", customer_id="")
+        await search(query="q")
+        kwargs = sdk.fetch.call_args.kwargs
+        assert kwargs.get("customer_id") is None
+
+
+# ---------------------------------------------------------------------------
+# create_search_tool — failure paths
+# ---------------------------------------------------------------------------
+
+
+class TestSearchToolFailurePath:
+    @pytest.mark.asyncio
+    async def test_raises_synap_integration_error_on_sdk_failure(self):
+        sdk = _sdk()
+        sdk.fetch = AsyncMock(side_effect=RuntimeError("sdk boom"))
+        search = create_search_tool(sdk, user_id="u1")
+        with pytest.raises(SynapIntegrationError):
+            await search(query="any query")
+
+    @pytest.mark.asyncio
+    async def test_synap_integration_error_chains_original_cause(self):
+        original = RuntimeError("original sdk error")
+        sdk = _sdk()
+        sdk.fetch = AsyncMock(side_effect=original)
+        search = create_search_tool(sdk, user_id="u1")
+        with pytest.raises(SynapIntegrationError) as exc_info:
+            await search(query="q")
+        assert exc_info.value.__cause__ is original
+
+    @pytest.mark.asyncio
+    async def test_failing_sdk_search_raises(self, failing_sdk):
+        """Shared failing_sdk fixture — get_context_for_prompt raises RuntimeError."""
+        # failing_sdk wires sdk.fetch to raise; so create_search_tool must propagate
+        search = create_search_tool(failing_sdk, user_id="u1")
+        with pytest.raises(SynapIntegrationError):
+            await search(query="anything")
+
+
+# ---------------------------------------------------------------------------
+# create_store_tool — construction validation
+# ---------------------------------------------------------------------------
+
+
+class TestCreateStoreToolValidation:
+    def test_raises_on_none_sdk(self):
+        with pytest.raises(ValueError, match="non-None sdk"):
+            create_store_tool(None, user_id="u1")  # type: ignore[arg-type]
+
+    def test_raises_on_empty_user_id(self):
+        sdk = _sdk()
+        with pytest.raises(ValueError, match="non-empty user_id"):
+            create_store_tool(sdk, user_id="")
+
+    def test_returns_async_callable(self):
+        sdk = _sdk()
+        fn = create_store_tool(sdk, user_id="u1")
+        assert callable(fn)
+        assert inspect.iscoroutinefunction(fn), "store_memory must be async"
+
+
+# ---------------------------------------------------------------------------
+# create_store_tool — happy paths
+# ---------------------------------------------------------------------------
+
+
+class TestStoreToolHappyPath:
+    @pytest.mark.asyncio
+    async def test_returns_string_with_ingestion_id(self):
+        sdk = _sdk(create_return=MagicMock(ingestion_id="ing-123"))
+        store = create_store_tool(sdk, user_id="u1")
+        result = await store(content="User prefers dark mode")
+        assert "ing-123" in result
+
+    @pytest.mark.asyncio
+    async def test_returns_string(self):
+        sdk = _sdk()
+        store = create_store_tool(sdk, user_id="u1")
+        result = await store(content="some content")
+        assert isinstance(result, str)
+
+    @pytest.mark.asyncio
+    async def test_forwards_document_to_memories_create(self):
+        sdk = _sdk()
+        store = create_store_tool(sdk, user_id="u1")
+        await store(content="User prefers dark mode")
+        sdk.memories.create.assert_awaited_once()
+        kwargs = sdk.memories.create.call_args.kwargs
+        assert kwargs["document"] == "User prefers dark mode"
+
+    @pytest.mark.asyncio
+    async def test_forwards_user_id_to_memories_create(self):
+        sdk = _sdk()
+        store = create_store_tool(sdk, user_id="user-99")
+        await store(content="some info")
+        kwargs = sdk.memories.create.call_args.kwargs
+        assert kwargs["user_id"] == "user-99"
+
+    @pytest.mark.asyncio
+    async def test_forwards_customer_id_to_memories_create(self):
+        sdk = _sdk()
+        store = create_store_tool(sdk, user_id="u1", customer_id="cust-42")
+        await store(content="info")
+        kwargs = sdk.memories.create.call_args.kwargs
+        assert kwargs["customer_id"] == "cust-42"
+
+    @pytest.mark.asyncio
+    async def test_empty_customer_id_forwarded_as_empty_string(self):
+        """Default customer_id='' is passed through to memories.create unchanged."""
+        sdk = _sdk()
+        store = create_store_tool(sdk, user_id="u1")
+        await store(content="info")
+        kwargs = sdk.memories.create.call_args.kwargs
+        assert kwargs["customer_id"] == ""
+
+    @pytest.mark.asyncio
+    async def test_mock_sdk_store_happy_path(self, mock_sdk):
+        """Shared mock_sdk harness: memories.create pre-wired to return ingestion_id=ing-001."""
+        store = create_store_tool(mock_sdk, user_id="u1")
+        result = await store(content="remember this")
+        assert "ing-001" in result
+
+
+# ---------------------------------------------------------------------------
+# create_store_tool — failure paths
+# ---------------------------------------------------------------------------
+
+
+class TestStoreToolFailurePath:
+    @pytest.mark.asyncio
+    async def test_raises_synap_integration_error_on_sdk_failure(self):
+        sdk = _sdk()
+        sdk.memories.create = AsyncMock(side_effect=RuntimeError("sdk boom"))
+        store = create_store_tool(sdk, user_id="u1")
+        with pytest.raises(SynapIntegrationError):
+            await store(content="content to store")
+
+    @pytest.mark.asyncio
+    async def test_synap_integration_error_chains_original_cause(self):
+        original = RuntimeError("original error")
+        sdk = _sdk()
+        sdk.memories.create = AsyncMock(side_effect=original)
+        store = create_store_tool(sdk, user_id="u1")
+        with pytest.raises(SynapIntegrationError) as exc_info:
+            await store(content="content")
+        assert exc_info.value.__cause__ is original
+
+    @pytest.mark.asyncio
+    async def test_failing_sdk_store_raises(self, failing_sdk):
+        """Shared failing_sdk fixture — sdk.memories.create raises RuntimeError."""
+        store = create_store_tool(failing_sdk, user_id="u1")
+        with pytest.raises(SynapIntegrationError):
+            await store(content="anything")

--- a/packages/integrations/synap-mirascope/README.md
+++ b/packages/integrations/synap-mirascope/README.md
@@ -1,0 +1,31 @@
+# Synap + Mirascope
+
+Synap memory tools and short-term context helpers for [Mirascope](https://pypi.org/).
+
+## Install
+
+```bash
+pip install maximem-synap maximem-synap-mirascope
+```
+
+## Usage
+
+```python
+from maximem_synap import MaximemSynapSDK
+from synap_mirascope import create_search_tool, create_store_tool, synap_st_instructions
+
+sdk = MaximemSynapSDK(api_key="your-api-key")
+await sdk.initialize()
+
+search = create_search_tool(sdk, user_id="alice", conversation_id="conv-1")
+store = create_store_tool(sdk, user_id="alice")
+
+# Dynamic system prompt via synap_st_instructions
+instructions = synap_st_instructions(
+    sdk,
+    conversation_id="conv-1",
+    system="You are a helpful assistant.",
+)
+```
+
+See the root repo README for scoping (`user_id`, `customer_id`, `conversation_id`) and benchmark context.

--- a/packages/integrations/synap-mirascope/pyproject.toml
+++ b/packages/integrations/synap-mirascope/pyproject.toml
@@ -1,0 +1,23 @@
+[build-system]
+requires = ["setuptools>=61.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "maximem-synap-mirascope"
+version = "0.2.0"
+description = "Synap memory integration for Mirascope"
+readme = "README.md"
+requires-python = ">=3.11"
+license = "Apache-2.0"
+dependencies = ["maximem-synap>=0.2.0", "maximem-synap-integrations-common>=0.1.0", "mirascope>=1.0"]
+
+[project.optional-dependencies]
+dev = ["pytest>=7.0", "pytest-asyncio>=0.21"]
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["synap_mirascope*"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+asyncio_mode = "auto"

--- a/packages/integrations/synap-mirascope/synap_mirascope/__init__.py
+++ b/packages/integrations/synap-mirascope/synap_mirascope/__init__.py
@@ -1,0 +1,10 @@
+"""Synap memory integration for Mirascope."""
+
+from synap_mirascope.short_term import synap_st_instructions
+from synap_mirascope.tools import create_search_tool, create_store_tool
+
+__all__ = [
+    "create_search_tool",
+    "create_store_tool",
+    "synap_st_instructions",
+]

--- a/packages/integrations/synap-mirascope/synap_mirascope/short_term.py
+++ b/packages/integrations/synap-mirascope/synap_mirascope/short_term.py
@@ -1,0 +1,163 @@
+"""Synap short-term context for Mirascope.
+
+Mirrors the LangGraph template: a single thin wrapper around
+``sdk.conversation.context.get_context_for_prompt``. Quality contract is
+identical to the LangGraph adapter (see synap_langgraph.short_term).
+
+Mirascope accepts ``Agent(instructions=...)`` where ``instructions``
+can be a string OR an async callable receiving ``(context, agent)`` and
+returning a string. :func:`synap_st_instructions` returns the second
+form: each agent step calls into the SDK helper (cache-first), prepends
+the ST block above your own system text inside the configured preamble
+tags, and returns the combined instructions string.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Awaitable, Callable, Literal, Optional
+
+from maximem_synap import MaximemSynapSDK
+from synap_integrations_common import (
+    SynapIntegrationError,
+    wrap_sdk_errors_async,
+)
+
+logger = logging.getLogger(__name__)
+
+_SUPPORTED_STYLES = ("structured", "narrative", "bullet_points")
+_DEFAULT_OPEN = "<synap_short_term_context>"
+_DEFAULT_CLOSE = "</synap_short_term_context>"
+
+_OnError = Literal["fallback", "raise"]
+
+
+def _validate_args(
+    sdk: Optional[MaximemSynapSDK],
+    conversation_id: str,
+    style: str,
+    on_error: str,
+    site: str,
+) -> None:
+    if sdk is None:
+        raise ValueError(f"{site} requires a non-None sdk")
+    if not conversation_id or not str(conversation_id).strip():
+        raise ValueError(f"{site} requires a non-empty conversation_id")
+    if style not in _SUPPORTED_STYLES:
+        raise ValueError(
+            f"{site}: unsupported style={style!r}; expected one of {_SUPPORTED_STYLES}"
+        )
+    if on_error not in ("fallback", "raise"):
+        raise ValueError(
+            f"{site}: on_error must be 'fallback' or 'raise', got {on_error!r}"
+        )
+
+
+async def _fetch_st_block(
+    sdk: MaximemSynapSDK,
+    conversation_id: str,
+    style: str,
+    on_error: _OnError,
+    site: str,
+) -> str:
+    try:
+        async with wrap_sdk_errors_async(
+            site,
+            logger,
+            conversation_id=conversation_id,
+            style=style,
+        ):
+            response = await sdk.conversation.context.get_context_for_prompt(
+                conversation_id=conversation_id,
+                style=style,
+            )
+    except SynapIntegrationError:
+        if on_error == "raise":
+            raise
+        return ""
+    if not getattr(response, "available", False):
+        return ""
+    formatted = getattr(response, "formatted_context", None)
+    return (formatted or "").strip()
+
+
+def _compose(
+    st_block: str,
+    user_system: str,
+    preamble_open: Optional[str],
+    preamble_close: Optional[str],
+) -> str:
+    parts = []
+    st_block = (st_block or "").strip()
+    user_system = (user_system or "").strip()
+    if st_block:
+        if preamble_open and preamble_close:
+            parts.append(f"{preamble_open}\n{st_block}\n{preamble_close}")
+        else:
+            parts.append(st_block)
+    if user_system:
+        parts.append(user_system)
+    return "\n\n".join(parts)
+
+
+def synap_st_instructions(
+    sdk: MaximemSynapSDK,
+    conversation_id: str,
+    *,
+    system: str = "",
+    style: str = "narrative",
+    preamble_open: Optional[str] = _DEFAULT_OPEN,
+    preamble_close: Optional[str] = _DEFAULT_CLOSE,
+    on_error: _OnError = "fallback",
+) -> Callable[[Any, Any], Awaitable[str]]:
+    """Return an async ``instructions`` callable for Mirascope.
+
+    The callable matches Mirascope' expected signature
+    ``async (context, agent) -> str``. Both arguments are ignored — we
+    use the explicitly-bound ``conversation_id`` rather than inferring
+    from any framework-internal session.
+
+    Args:
+        sdk: Initialised :class:`MaximemSynapSDK`.
+        conversation_id: Synap conversation ID. **Required.**
+        system: Your own agent instructions; ST is prepended above.
+        style: One of ``"structured" | "narrative" | "bullet_points"``.
+        preamble_open / preamble_close: Wrapping tags; pass ``None`` for
+            both to drop the tags.
+        on_error: ``"fallback"`` (default) returns bare ``system`` on
+            SDK failure; ``"raise"`` propagates :class:`SynapIntegrationError`.
+
+    Example::
+
+        # from Mirascope import Agent  # example
+        from maximem_synap import MaximemSynapSDK
+        from synap_mirascope import synap_st_instructions
+
+        sdk = MaximemSynapSDK(api_key="sk-...")
+        agent = Agent(
+            name="support",
+            instructions=synap_st_instructions(
+                sdk,
+                conversation_id="conv_abc",
+                system="You are a polite support agent.",
+            ),
+            tools=[...],
+        )
+    """
+    _validate_args(sdk, conversation_id, style, on_error, "synap_st_instructions")
+
+    async def _instructions(context: Any, agent: Any) -> str:  # noqa: ARG001 — framework signature
+        st_block = await _fetch_st_block(
+            sdk,
+            conversation_id,
+            style,
+            on_error,
+            site="synap_mirascope.synap_st_instructions",
+        )
+        return _compose(st_block, system, preamble_open, preamble_close)
+
+    _instructions.__name__ = "synap_st_instructions"
+    return _instructions
+
+
+__all__ = ["synap_st_instructions"]

--- a/packages/integrations/synap-mirascope/synap_mirascope/tools.py
+++ b/packages/integrations/synap-mirascope/synap_mirascope/tools.py
@@ -1,0 +1,79 @@
+"""Synap tools for Mirascope.
+
+Provides memory search/store callables for Mirascope agents.
+SDK failures are wrapped in :class:`SynapIntegrationError`.
+"""
+
+import logging
+from typing import Optional
+
+from maximem_synap import MaximemSynapSDK
+from synap_integrations_common import wrap_sdk_errors_async
+
+logger = logging.getLogger(__name__)
+
+
+def create_search_tool(
+    sdk: MaximemSynapSDK,
+    user_id: str,
+    customer_id: str = "",
+    conversation_id: Optional[str] = None,
+):
+    """Create a memory search callable for Mirascope.
+
+    Example::
+
+        search_fn = create_search_tool(sdk, user_id="u1")
+        # Wire into your Mirascope agent: @llm.tool async def search_memory(...)
+    """
+    if sdk is None:
+        raise ValueError("create_search_tool requires a non-None sdk")
+    if not user_id:
+        raise ValueError("create_search_tool requires a non-empty user_id")
+
+    async def search_memory(query: str) -> str:
+        """Search the user's memory for relevant context."""
+        async with wrap_sdk_errors_async(
+            "mirascope.search_memory",
+            logger,
+            user_id=user_id,
+        ):
+            response = await sdk.fetch(
+                conversation_id=conversation_id,
+                user_id=user_id,
+                customer_id=customer_id or None,
+                search_query=[query],
+                mode="accurate",
+                include_conversation_context=False,
+            )
+        return response.formatted_context or "No relevant memories found."
+
+    return search_memory
+
+
+def create_store_tool(
+    sdk: MaximemSynapSDK,
+    user_id: str,
+    customer_id: str = "",
+):
+    """Create a memory store callable for Mirascope."""
+    if sdk is None:
+        raise ValueError("create_store_tool requires a non-None sdk")
+    if not user_id:
+        raise ValueError("create_store_tool requires a non-empty user_id")
+
+    async def store_memory(content: str) -> str:
+        """Store important information about the user for future reference."""
+        async with wrap_sdk_errors_async(
+            "mirascope.store_memory",
+            logger,
+            user_id=user_id,
+        ):
+            result = await sdk.memories.create(
+                document=content,
+                user_id=user_id,
+                customer_id=customer_id,
+            )
+        return f"Memory stored (ingestion_id: {result.ingestion_id})"
+
+    return store_memory

--- a/packages/integrations/synap-mirascope/tests/conftest.py
+++ b/packages/integrations/synap-mirascope/tests/conftest.py
@@ -1,0 +1,26 @@
+"""Pytest conftest for synap-openai-agents tests.
+
+Re-exports fixtures and factories from the shared harness so every test file
+can rely on a single, canonical source of truth.
+"""
+
+import sys
+import os
+
+# Ensure local packages are importable when running from repo root.
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../synap/sdk/python"))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(
+    0, os.path.join(os.path.dirname(__file__), "../../synap-integrations-common")
+)
+
+from synap_integrations_common.testing import (  # noqa: F401
+    mock_sdk,
+    failing_sdk,
+    make_fact,
+    make_preference,
+    make_episode,
+    make_emotion,
+    make_temporal_event,
+    make_unified_response,
+)

--- a/packages/integrations/synap-mirascope/tests/test_short_term.py
+++ b/packages/integrations/synap-mirascope/tests/test_short_term.py
@@ -1,0 +1,376 @@
+"""Tests for synap_mirascope.short_term — synap_st_instructions.
+
+Covers:
+- Construction validation (sdk=None, empty/whitespace conversation_id, unknown style,
+  invalid on_error)
+- Happy paths: ST block present, preamble wrapping, style forwarding, all 3 styles accepted
+- Empty-ST safety: unavailable flag, None formatted_context, empty string
+- Error policies: fallback (on_error="fallback") returns bare system, raise propagates
+  SynapIntegrationError
+- Callable contract: returned value is an async callable accepting (context, agent)
+- Harness: failing_sdk fixture
+- Public surface: __all__ exports
+"""
+
+from __future__ import annotations
+
+import inspect
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from synap_mirascope.short_term import synap_st_instructions
+from synap_integrations_common import SynapIntegrationError
+
+
+# ---------------------------------------------------------------------------
+# Local helpers — minimal, keep tests readable
+# ---------------------------------------------------------------------------
+
+
+def _make_response(formatted: str | None, available: bool = True):
+    resp = MagicMock()
+    resp.available = available
+    resp.formatted_context = formatted
+    return resp
+
+
+def _fake_sdk(
+    formatted: str | None = "User prefers concise replies.", available: bool = True
+):
+    sdk = MagicMock()
+    sdk.conversation.context.get_context_for_prompt = AsyncMock(
+        return_value=_make_response(formatted, available)
+    )
+    return sdk
+
+
+# ---------------------------------------------------------------------------
+# Construction validation
+# ---------------------------------------------------------------------------
+
+
+class TestValidation:
+    def test_requires_sdk(self):
+        with pytest.raises(ValueError, match="non-None sdk"):
+            synap_st_instructions(None, "conv_abc")  # type: ignore[arg-type]
+
+    def test_requires_nonempty_conversation_id(self):
+        sdk = _fake_sdk()
+        with pytest.raises(ValueError, match="non-empty conversation_id"):
+            synap_st_instructions(sdk, "")
+
+    def test_rejects_whitespace_only_conversation_id(self):
+        sdk = _fake_sdk()
+        with pytest.raises(ValueError, match="non-empty conversation_id"):
+            synap_st_instructions(sdk, "   ")
+
+    def test_rejects_unknown_style(self):
+        sdk = _fake_sdk()
+        with pytest.raises(ValueError, match="unsupported style"):
+            synap_st_instructions(sdk, "conv_abc", style="poetic")
+
+    def test_rejects_invalid_on_error(self):
+        sdk = _fake_sdk()
+        with pytest.raises(ValueError, match="on_error"):
+            synap_st_instructions(sdk, "conv_abc", on_error="ignore")  # type: ignore[arg-type]
+
+    def test_accepts_all_supported_styles(self):
+        sdk = _fake_sdk()
+        for style in ("structured", "narrative", "bullet_points"):
+            # Should NOT raise
+            fn = synap_st_instructions(sdk, "conv_abc", style=style)
+            assert callable(fn), f"should return callable for style={style!r}"
+
+
+# ---------------------------------------------------------------------------
+# Callable contract
+# ---------------------------------------------------------------------------
+
+
+class TestCallableContract:
+    def test_returns_async_callable(self):
+        sdk = _fake_sdk()
+        fn = synap_st_instructions(sdk, "conv_abc")
+        assert callable(fn)
+        assert inspect.iscoroutinefunction(fn), "instructions must be async"
+
+    def test_callable_is_named(self):
+        sdk = _fake_sdk()
+        fn = synap_st_instructions(sdk, "conv_abc")
+        assert fn.__name__ == "synap_st_instructions"
+
+    @pytest.mark.asyncio
+    async def test_accepts_two_positional_args(self):
+        """OpenAI Agents calls instructions(context, agent) — both args must be accepted."""
+        sdk = _fake_sdk(formatted="ctx")
+        fn = synap_st_instructions(sdk, "conv_abc", system="sys")
+        # Should not raise with two MagicMock positional arguments
+        result = await fn(MagicMock(), MagicMock())
+        assert isinstance(result, str)
+
+
+# ---------------------------------------------------------------------------
+# Happy paths — ST present
+# ---------------------------------------------------------------------------
+
+
+class TestHappyPath:
+    @pytest.mark.asyncio
+    async def test_returns_combined_instructions_with_default_preamble(self):
+        sdk = _fake_sdk(formatted="User likes Markdown.")
+        instr = synap_st_instructions(sdk, "conv_abc", system="You are a coding agent.")
+        result = await instr(MagicMock(), MagicMock())
+        assert "<synap_short_term_context>" in result
+        assert "User likes Markdown." in result
+        assert "</synap_short_term_context>" in result
+        assert "You are a coding agent." in result
+        # ST block must appear before user system text
+        assert result.index("User likes Markdown") < result.index("coding agent")
+
+    @pytest.mark.asyncio
+    async def test_passes_conversation_id_and_style_to_sdk(self):
+        sdk = _fake_sdk()
+        instr = synap_st_instructions(
+            sdk, "conv_xyz", style="bullet_points", system="X"
+        )
+        await instr(MagicMock(), MagicMock())
+        sdk.conversation.context.get_context_for_prompt.assert_awaited_once_with(
+            conversation_id="conv_xyz",
+            style="bullet_points",
+        )
+
+    @pytest.mark.asyncio
+    async def test_default_style_is_narrative(self):
+        sdk = _fake_sdk()
+        instr = synap_st_instructions(sdk, "conv_abc", system="X")
+        await instr(MagicMock(), MagicMock())
+        sdk.conversation.context.get_context_for_prompt.assert_awaited_once_with(
+            conversation_id="conv_abc",
+            style="narrative",
+        )
+
+    @pytest.mark.asyncio
+    async def test_custom_preamble_tags(self):
+        sdk = _fake_sdk(formatted="X")
+        instr = synap_st_instructions(
+            sdk,
+            "conv_abc",
+            system="sys",
+            preamble_open="[BEGIN]",
+            preamble_close="[END]",
+        )
+        out = await instr(MagicMock(), MagicMock())
+        assert "[BEGIN]" in out
+        assert "[END]" in out
+        assert "<synap_short_term_context>" not in out
+
+    @pytest.mark.asyncio
+    async def test_no_preamble_raw_concat(self):
+        """When both preamble tags are None, ST and system are joined with double newline."""
+        sdk = _fake_sdk(formatted="raw st")
+        instr = synap_st_instructions(
+            sdk,
+            "conv_abc",
+            system="user sys",
+            preamble_open=None,
+            preamble_close=None,
+        )
+        out = await instr(MagicMock(), MagicMock())
+        assert out == "raw st\n\nuser sys"
+
+    @pytest.mark.asyncio
+    async def test_st_only_no_system(self):
+        """When system is empty, only the ST block (with preamble) is returned."""
+        sdk = _fake_sdk(formatted="context block")
+        instr = synap_st_instructions(sdk, "conv_abc", system="")
+        out = await instr(MagicMock(), MagicMock())
+        assert "context block" in out
+        assert "<synap_short_term_context>" in out
+
+    @pytest.mark.asyncio
+    async def test_structured_style_forwarded(self):
+        sdk = _fake_sdk()
+        instr = synap_st_instructions(sdk, "conv_abc", style="structured")
+        await instr(MagicMock(), MagicMock())
+        sdk.conversation.context.get_context_for_prompt.assert_awaited_once_with(
+            conversation_id="conv_abc",
+            style="structured",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Empty / unavailable ST
+# ---------------------------------------------------------------------------
+
+
+class TestEmptyST:
+    @pytest.mark.asyncio
+    async def test_unavailable_returns_user_system_only(self):
+        sdk = _fake_sdk(formatted=None, available=False)
+        instr = synap_st_instructions(sdk, "conv_abc", system="You are friendly.")
+        out = await instr(MagicMock(), MagicMock())
+        assert out == "You are friendly."
+
+    @pytest.mark.asyncio
+    async def test_unavailable_empty_system_returns_empty_string(self):
+        sdk = _fake_sdk(formatted=None, available=False)
+        instr = synap_st_instructions(sdk, "conv_abc", system="")
+        out = await instr(MagicMock(), MagicMock())
+        assert out == ""
+
+    @pytest.mark.asyncio
+    async def test_none_formatted_context_with_available_true_treated_as_empty(self):
+        """Even if available=True, a None formatted_context yields no ST block."""
+        sdk = _fake_sdk(formatted=None, available=True)
+        instr = synap_st_instructions(sdk, "conv_abc", system="sys")
+        out = await instr(MagicMock(), MagicMock())
+        assert out == "sys"
+        assert "<synap_short_term_context>" not in out
+
+    @pytest.mark.asyncio
+    async def test_empty_string_formatted_context_treated_as_empty(self):
+        sdk = _fake_sdk(formatted="", available=True)
+        instr = synap_st_instructions(sdk, "conv_abc", system="sys")
+        out = await instr(MagicMock(), MagicMock())
+        assert out == "sys"
+
+    @pytest.mark.asyncio
+    async def test_whitespace_only_formatted_context_treated_as_empty(self):
+        sdk = _fake_sdk(formatted="   ", available=True)
+        instr = synap_st_instructions(sdk, "conv_abc", system="sys")
+        out = await instr(MagicMock(), MagicMock())
+        assert out == "sys"
+
+
+# ---------------------------------------------------------------------------
+# Error policies
+# ---------------------------------------------------------------------------
+
+
+class TestErrorPolicies:
+    @pytest.mark.asyncio
+    async def test_fallback_on_sdk_failure_returns_user_system(self):
+        sdk = MagicMock()
+        sdk.conversation.context.get_context_for_prompt = AsyncMock(
+            side_effect=RuntimeError("sdk boom")
+        )
+        instr = synap_st_instructions(
+            sdk, "conv_abc", system="Stay calm.", on_error="fallback"
+        )
+        out = await instr(MagicMock(), MagicMock())
+        assert out == "Stay calm."
+
+    @pytest.mark.asyncio
+    async def test_fallback_empty_system_returns_empty_string(self):
+        sdk = MagicMock()
+        sdk.conversation.context.get_context_for_prompt = AsyncMock(
+            side_effect=RuntimeError("sdk boom")
+        )
+        instr = synap_st_instructions(sdk, "conv_abc", system="", on_error="fallback")
+        out = await instr(MagicMock(), MagicMock())
+        assert out == ""
+
+    @pytest.mark.asyncio
+    async def test_raise_propagates_synap_integration_error(self):
+        sdk = MagicMock()
+        sdk.conversation.context.get_context_for_prompt = AsyncMock(
+            side_effect=RuntimeError("sdk boom")
+        )
+        instr = synap_st_instructions(sdk, "conv_abc", system="X", on_error="raise")
+        with pytest.raises(SynapIntegrationError):
+            await instr(MagicMock(), MagicMock())
+
+    @pytest.mark.asyncio
+    async def test_raise_chains_original_cause(self):
+        original = RuntimeError("original sdk error")
+        sdk = MagicMock()
+        sdk.conversation.context.get_context_for_prompt = AsyncMock(
+            side_effect=original
+        )
+        instr = synap_st_instructions(sdk, "conv_abc", system="X", on_error="raise")
+        with pytest.raises(SynapIntegrationError) as exc_info:
+            await instr(MagicMock(), MagicMock())
+        assert exc_info.value.__cause__ is original
+
+    @pytest.mark.asyncio
+    async def test_synap_integration_error_passthrough_on_raise(self):
+        """A SynapIntegrationError raised by the SDK should propagate without double-wrapping."""
+        sdk = MagicMock()
+        original = SynapIntegrationError("op", "direct error")
+        sdk.conversation.context.get_context_for_prompt = AsyncMock(
+            side_effect=original
+        )
+        instr = synap_st_instructions(sdk, "conv_abc", system="X", on_error="raise")
+        with pytest.raises(SynapIntegrationError) as exc_info:
+            await instr(MagicMock(), MagicMock())
+        # Should be exactly the original instance (not a new wrapper)
+        assert exc_info.value is original
+
+
+# ---------------------------------------------------------------------------
+# failing_sdk harness fixture
+# ---------------------------------------------------------------------------
+
+
+class TestFailingSdkHarness:
+    @pytest.mark.asyncio
+    async def test_fallback_with_failing_sdk(self, failing_sdk):
+        """failing_sdk triggers fallback; system text is returned unmodified."""
+        instr = synap_st_instructions(
+            failing_sdk, "conv_abc", system="fallback text", on_error="fallback"
+        )
+        out = await instr(MagicMock(), MagicMock())
+        assert out == "fallback text"
+
+    @pytest.mark.asyncio
+    async def test_raise_with_failing_sdk_surfaces_error(self, failing_sdk):
+        """failing_sdk with on_error='raise' must propagate as SynapIntegrationError."""
+        instr = synap_st_instructions(
+            failing_sdk, "conv_abc", system="X", on_error="raise"
+        )
+        with pytest.raises(SynapIntegrationError):
+            await instr(MagicMock(), MagicMock())
+
+
+# ---------------------------------------------------------------------------
+# mock_sdk harness fixture
+# ---------------------------------------------------------------------------
+
+
+class TestMockSdkHarness:
+    @pytest.mark.asyncio
+    async def test_mock_sdk_happy_path(self, mock_sdk):
+        """mock_sdk pre-wires get_context_for_prompt → returns a combined instructions string."""
+        instr = synap_st_instructions(
+            mock_sdk, "conv_abc", system="Agent system prompt."
+        )
+        out = await instr(MagicMock(), MagicMock())
+        assert isinstance(out, str)
+        # Combined output contains ST and user system text
+        assert "Agent system prompt." in out
+
+
+# ---------------------------------------------------------------------------
+# Public surface
+# ---------------------------------------------------------------------------
+
+
+class TestPublicSurface:
+    def test_module_exports_synap_st_instructions(self):
+        import synap_mirascope
+
+        assert hasattr(synap_mirascope, "synap_st_instructions")
+        assert "synap_st_instructions" in synap_mirascope.__all__
+
+    def test_create_search_tool_exported(self):
+        import synap_mirascope
+
+        assert hasattr(synap_mirascope, "create_search_tool")
+        assert "create_search_tool" in synap_mirascope.__all__
+
+    def test_create_store_tool_exported(self):
+        import synap_mirascope
+
+        assert hasattr(synap_mirascope, "create_store_tool")
+        assert "create_store_tool" in synap_mirascope.__all__

--- a/packages/integrations/synap-mirascope/tests/test_tools.py
+++ b/packages/integrations/synap-mirascope/tests/test_tools.py
@@ -1,0 +1,324 @@
+"""Tests for synap_mirascope.tools — create_search_tool / create_store_tool.
+
+Documented error-handling contract (from tools.py / wrap_sdk_errors_async):
+- Both factory functions validate sdk != None and user_id != "".
+- The returned async callables wrap SDK errors as SynapIntegrationError.
+- Callers (agent frameworks / test harnesses) decide how to handle the error.
+
+Covers:
+- Construction validation: sdk=None, empty user_id for both factories
+- search_memory happy paths: result forwarding, kwargs forwarded to sdk.fetch,
+  None/empty formatted_context fallback sentinel, conversation_id threading,
+  customer_id threading
+- store_memory happy paths: ingestion_id in return, kwargs forwarded to
+  sdk.memories.create, customer_id pass-through
+- Failure paths: SynapIntegrationError raised on SDK failure (both tools)
+- failing_sdk harness fixture
+- Public surface exports
+"""
+
+from __future__ import annotations
+
+import inspect
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from synap_mirascope.tools import create_search_tool, create_store_tool
+from synap_integrations_common import SynapIntegrationError
+
+
+# ---------------------------------------------------------------------------
+# Local helper: minimal SDK mock (unit-level, independent of shared harness)
+# ---------------------------------------------------------------------------
+
+
+def _sdk(fetch_return=None, create_return=None):
+    sdk = MagicMock()
+    sdk.fetch = AsyncMock(
+        return_value=fetch_return or MagicMock(formatted_context="ctx")
+    )
+    sdk.memories = MagicMock()
+    sdk.memories.create = AsyncMock(
+        return_value=create_return or MagicMock(ingestion_id="ing-001")
+    )
+    return sdk
+
+
+# ---------------------------------------------------------------------------
+# Public surface
+# ---------------------------------------------------------------------------
+
+
+def test_package_exports_create_search_tool():
+    from synap_mirascope import create_search_tool
+
+    assert create_search_tool is not None
+
+
+def test_package_exports_create_store_tool():
+    from synap_mirascope import create_store_tool
+
+    assert create_store_tool is not None
+
+
+# ---------------------------------------------------------------------------
+# create_search_tool — construction validation
+# ---------------------------------------------------------------------------
+
+
+class TestCreateSearchToolValidation:
+    def test_raises_on_none_sdk(self):
+        with pytest.raises(ValueError, match="non-None sdk"):
+            create_search_tool(None, user_id="u1")  # type: ignore[arg-type]
+
+    def test_raises_on_empty_user_id(self):
+        sdk = _sdk()
+        with pytest.raises(ValueError, match="non-empty user_id"):
+            create_search_tool(sdk, user_id="")
+
+    def test_returns_async_callable(self):
+        sdk = _sdk()
+        fn = create_search_tool(sdk, user_id="u1")
+        assert callable(fn)
+        assert inspect.iscoroutinefunction(fn), "search_memory must be async"
+
+
+# ---------------------------------------------------------------------------
+# create_search_tool — happy paths
+# ---------------------------------------------------------------------------
+
+
+class TestSearchToolHappyPath:
+    @pytest.mark.asyncio
+    async def test_returns_formatted_context(self):
+        sdk = _sdk(fetch_return=MagicMock(formatted_context="User likes tea"))
+        search = create_search_tool(sdk, user_id="u1")
+        result = await search(query="tea")
+        assert result == "User likes tea"
+
+    @pytest.mark.asyncio
+    async def test_forwards_query_as_list(self):
+        sdk = _sdk()
+        search = create_search_tool(sdk, user_id="u1")
+        await search(query="coffee preferences")
+        sdk.fetch.assert_awaited_once()
+        assert sdk.fetch.call_args.kwargs["search_query"] == ["coffee preferences"]
+
+    @pytest.mark.asyncio
+    async def test_forwards_user_id(self):
+        sdk = _sdk()
+        search = create_search_tool(sdk, user_id="user-42")
+        await search(query="q")
+        assert sdk.fetch.call_args.kwargs["user_id"] == "user-42"
+
+    @pytest.mark.asyncio
+    async def test_mode_is_accurate(self):
+        sdk = _sdk()
+        search = create_search_tool(sdk, user_id="u1")
+        await search(query="q")
+        assert sdk.fetch.call_args.kwargs["mode"] == "accurate"
+
+    @pytest.mark.asyncio
+    async def test_include_conversation_context_is_false(self):
+        sdk = _sdk()
+        search = create_search_tool(sdk, user_id="u1")
+        await search(query="q")
+        assert sdk.fetch.call_args.kwargs["include_conversation_context"] is False
+
+    @pytest.mark.asyncio
+    async def test_none_formatted_context_returns_sentinel(self):
+        sdk = _sdk(fetch_return=MagicMock(formatted_context=None))
+        search = create_search_tool(sdk, user_id="u1")
+        result = await search(query="unknown")
+        assert result == "No relevant memories found."
+
+    @pytest.mark.asyncio
+    async def test_empty_string_formatted_context_returns_sentinel(self):
+        sdk = _sdk(fetch_return=MagicMock(formatted_context=""))
+        search = create_search_tool(sdk, user_id="u1")
+        result = await search(query="unknown")
+        assert result == "No relevant memories found."
+
+    @pytest.mark.asyncio
+    async def test_conversation_id_forwarded_when_provided(self):
+        sdk = _sdk()
+        search = create_search_tool(sdk, user_id="u1", conversation_id="conv-99")
+        await search(query="q")
+        assert sdk.fetch.call_args.kwargs["conversation_id"] == "conv-99"
+
+    @pytest.mark.asyncio
+    async def test_conversation_id_none_when_not_provided(self):
+        sdk = _sdk()
+        search = create_search_tool(sdk, user_id="u1")
+        await search(query="q")
+        # None or not present — depends on implementation; either is acceptable
+        kwargs = sdk.fetch.call_args.kwargs
+        assert kwargs.get("conversation_id") is None
+
+    @pytest.mark.asyncio
+    async def test_customer_id_forwarded(self):
+        sdk = _sdk()
+        search = create_search_tool(sdk, user_id="u1", customer_id="cust-7")
+        await search(query="q")
+        kwargs = sdk.fetch.call_args.kwargs
+        # customer_id='' maps to None internally; non-empty is forwarded as-is
+        assert kwargs.get("customer_id") == "cust-7"
+
+    @pytest.mark.asyncio
+    async def test_empty_customer_id_coerced_to_none(self):
+        """Empty customer_id is coerced to None before sdk.fetch per product code."""
+        sdk = _sdk()
+        search = create_search_tool(sdk, user_id="u1", customer_id="")
+        await search(query="q")
+        kwargs = sdk.fetch.call_args.kwargs
+        assert kwargs.get("customer_id") is None
+
+
+# ---------------------------------------------------------------------------
+# create_search_tool — failure paths
+# ---------------------------------------------------------------------------
+
+
+class TestSearchToolFailurePath:
+    @pytest.mark.asyncio
+    async def test_raises_synap_integration_error_on_sdk_failure(self):
+        sdk = _sdk()
+        sdk.fetch = AsyncMock(side_effect=RuntimeError("sdk boom"))
+        search = create_search_tool(sdk, user_id="u1")
+        with pytest.raises(SynapIntegrationError):
+            await search(query="any query")
+
+    @pytest.mark.asyncio
+    async def test_synap_integration_error_chains_original_cause(self):
+        original = RuntimeError("original sdk error")
+        sdk = _sdk()
+        sdk.fetch = AsyncMock(side_effect=original)
+        search = create_search_tool(sdk, user_id="u1")
+        with pytest.raises(SynapIntegrationError) as exc_info:
+            await search(query="q")
+        assert exc_info.value.__cause__ is original
+
+    @pytest.mark.asyncio
+    async def test_failing_sdk_search_raises(self, failing_sdk):
+        """Shared failing_sdk fixture — get_context_for_prompt raises RuntimeError."""
+        # failing_sdk wires sdk.fetch to raise; so create_search_tool must propagate
+        search = create_search_tool(failing_sdk, user_id="u1")
+        with pytest.raises(SynapIntegrationError):
+            await search(query="anything")
+
+
+# ---------------------------------------------------------------------------
+# create_store_tool — construction validation
+# ---------------------------------------------------------------------------
+
+
+class TestCreateStoreToolValidation:
+    def test_raises_on_none_sdk(self):
+        with pytest.raises(ValueError, match="non-None sdk"):
+            create_store_tool(None, user_id="u1")  # type: ignore[arg-type]
+
+    def test_raises_on_empty_user_id(self):
+        sdk = _sdk()
+        with pytest.raises(ValueError, match="non-empty user_id"):
+            create_store_tool(sdk, user_id="")
+
+    def test_returns_async_callable(self):
+        sdk = _sdk()
+        fn = create_store_tool(sdk, user_id="u1")
+        assert callable(fn)
+        assert inspect.iscoroutinefunction(fn), "store_memory must be async"
+
+
+# ---------------------------------------------------------------------------
+# create_store_tool — happy paths
+# ---------------------------------------------------------------------------
+
+
+class TestStoreToolHappyPath:
+    @pytest.mark.asyncio
+    async def test_returns_string_with_ingestion_id(self):
+        sdk = _sdk(create_return=MagicMock(ingestion_id="ing-123"))
+        store = create_store_tool(sdk, user_id="u1")
+        result = await store(content="User prefers dark mode")
+        assert "ing-123" in result
+
+    @pytest.mark.asyncio
+    async def test_returns_string(self):
+        sdk = _sdk()
+        store = create_store_tool(sdk, user_id="u1")
+        result = await store(content="some content")
+        assert isinstance(result, str)
+
+    @pytest.mark.asyncio
+    async def test_forwards_document_to_memories_create(self):
+        sdk = _sdk()
+        store = create_store_tool(sdk, user_id="u1")
+        await store(content="User prefers dark mode")
+        sdk.memories.create.assert_awaited_once()
+        kwargs = sdk.memories.create.call_args.kwargs
+        assert kwargs["document"] == "User prefers dark mode"
+
+    @pytest.mark.asyncio
+    async def test_forwards_user_id_to_memories_create(self):
+        sdk = _sdk()
+        store = create_store_tool(sdk, user_id="user-99")
+        await store(content="some info")
+        kwargs = sdk.memories.create.call_args.kwargs
+        assert kwargs["user_id"] == "user-99"
+
+    @pytest.mark.asyncio
+    async def test_forwards_customer_id_to_memories_create(self):
+        sdk = _sdk()
+        store = create_store_tool(sdk, user_id="u1", customer_id="cust-42")
+        await store(content="info")
+        kwargs = sdk.memories.create.call_args.kwargs
+        assert kwargs["customer_id"] == "cust-42"
+
+    @pytest.mark.asyncio
+    async def test_empty_customer_id_forwarded_as_empty_string(self):
+        """Default customer_id='' is passed through to memories.create unchanged."""
+        sdk = _sdk()
+        store = create_store_tool(sdk, user_id="u1")
+        await store(content="info")
+        kwargs = sdk.memories.create.call_args.kwargs
+        assert kwargs["customer_id"] == ""
+
+    @pytest.mark.asyncio
+    async def test_mock_sdk_store_happy_path(self, mock_sdk):
+        """Shared mock_sdk harness: memories.create pre-wired to return ingestion_id=ing-001."""
+        store = create_store_tool(mock_sdk, user_id="u1")
+        result = await store(content="remember this")
+        assert "ing-001" in result
+
+
+# ---------------------------------------------------------------------------
+# create_store_tool — failure paths
+# ---------------------------------------------------------------------------
+
+
+class TestStoreToolFailurePath:
+    @pytest.mark.asyncio
+    async def test_raises_synap_integration_error_on_sdk_failure(self):
+        sdk = _sdk()
+        sdk.memories.create = AsyncMock(side_effect=RuntimeError("sdk boom"))
+        store = create_store_tool(sdk, user_id="u1")
+        with pytest.raises(SynapIntegrationError):
+            await store(content="content to store")
+
+    @pytest.mark.asyncio
+    async def test_synap_integration_error_chains_original_cause(self):
+        original = RuntimeError("original error")
+        sdk = _sdk()
+        sdk.memories.create = AsyncMock(side_effect=original)
+        store = create_store_tool(sdk, user_id="u1")
+        with pytest.raises(SynapIntegrationError) as exc_info:
+            await store(content="content")
+        assert exc_info.value.__cause__ is original
+
+    @pytest.mark.asyncio
+    async def test_failing_sdk_store_raises(self, failing_sdk):
+        """Shared failing_sdk fixture — sdk.memories.create raises RuntimeError."""
+        store = create_store_tool(failing_sdk, user_id="u1")
+        with pytest.raises(SynapIntegrationError):
+            await store(content="anything")

--- a/packages/integrations/synap-smolagents/README.md
+++ b/packages/integrations/synap-smolagents/README.md
@@ -1,0 +1,31 @@
+# Synap + Smolagents
+
+Synap memory tools and short-term context helpers for [Smolagents](https://pypi.org/).
+
+## Install
+
+```bash
+pip install maximem-synap maximem-synap-smolagents
+```
+
+## Usage
+
+```python
+from maximem_synap import MaximemSynapSDK
+from synap_smolagents import create_search_tool, create_store_tool, synap_st_instructions
+
+sdk = MaximemSynapSDK(api_key="your-api-key")
+await sdk.initialize()
+
+search = create_search_tool(sdk, user_id="alice", conversation_id="conv-1")
+store = create_store_tool(sdk, user_id="alice")
+
+# CodeAgent(system_prompt=synap_st_instructions(...))
+instructions = synap_st_instructions(
+    sdk,
+    conversation_id="conv-1",
+    system="You are a helpful assistant.",
+)
+```
+
+See the root repo README for scoping (`user_id`, `customer_id`, `conversation_id`) and benchmark context.

--- a/packages/integrations/synap-smolagents/pyproject.toml
+++ b/packages/integrations/synap-smolagents/pyproject.toml
@@ -1,0 +1,23 @@
+[build-system]
+requires = ["setuptools>=61.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "maximem-synap-smolagents"
+version = "0.2.0"
+description = "Synap memory integration for Smolagents"
+readme = "README.md"
+requires-python = ">=3.11"
+license = "Apache-2.0"
+dependencies = ["maximem-synap>=0.2.0", "maximem-synap-integrations-common>=0.1.0", "smolagents>=1.0"]
+
+[project.optional-dependencies]
+dev = ["pytest>=7.0", "pytest-asyncio>=0.21"]
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["synap_smolagents*"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+asyncio_mode = "auto"

--- a/packages/integrations/synap-smolagents/synap_smolagents/__init__.py
+++ b/packages/integrations/synap-smolagents/synap_smolagents/__init__.py
@@ -1,0 +1,10 @@
+"""Synap memory integration for Smolagents."""
+
+from synap_smolagents.short_term import synap_st_instructions
+from synap_smolagents.tools import create_search_tool, create_store_tool
+
+__all__ = [
+    "create_search_tool",
+    "create_store_tool",
+    "synap_st_instructions",
+]

--- a/packages/integrations/synap-smolagents/synap_smolagents/short_term.py
+++ b/packages/integrations/synap-smolagents/synap_smolagents/short_term.py
@@ -1,0 +1,163 @@
+"""Synap short-term context for Smolagents.
+
+Mirrors the LangGraph template: a single thin wrapper around
+``sdk.conversation.context.get_context_for_prompt``. Quality contract is
+identical to the LangGraph adapter (see synap_langgraph.short_term).
+
+Smolagents accepts ``Agent(instructions=...)`` where ``instructions``
+can be a string OR an async callable receiving ``(context, agent)`` and
+returning a string. :func:`synap_st_instructions` returns the second
+form: each agent step calls into the SDK helper (cache-first), prepends
+the ST block above your own system text inside the configured preamble
+tags, and returns the combined instructions string.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Awaitable, Callable, Literal, Optional
+
+from maximem_synap import MaximemSynapSDK
+from synap_integrations_common import (
+    SynapIntegrationError,
+    wrap_sdk_errors_async,
+)
+
+logger = logging.getLogger(__name__)
+
+_SUPPORTED_STYLES = ("structured", "narrative", "bullet_points")
+_DEFAULT_OPEN = "<synap_short_term_context>"
+_DEFAULT_CLOSE = "</synap_short_term_context>"
+
+_OnError = Literal["fallback", "raise"]
+
+
+def _validate_args(
+    sdk: Optional[MaximemSynapSDK],
+    conversation_id: str,
+    style: str,
+    on_error: str,
+    site: str,
+) -> None:
+    if sdk is None:
+        raise ValueError(f"{site} requires a non-None sdk")
+    if not conversation_id or not str(conversation_id).strip():
+        raise ValueError(f"{site} requires a non-empty conversation_id")
+    if style not in _SUPPORTED_STYLES:
+        raise ValueError(
+            f"{site}: unsupported style={style!r}; expected one of {_SUPPORTED_STYLES}"
+        )
+    if on_error not in ("fallback", "raise"):
+        raise ValueError(
+            f"{site}: on_error must be 'fallback' or 'raise', got {on_error!r}"
+        )
+
+
+async def _fetch_st_block(
+    sdk: MaximemSynapSDK,
+    conversation_id: str,
+    style: str,
+    on_error: _OnError,
+    site: str,
+) -> str:
+    try:
+        async with wrap_sdk_errors_async(
+            site,
+            logger,
+            conversation_id=conversation_id,
+            style=style,
+        ):
+            response = await sdk.conversation.context.get_context_for_prompt(
+                conversation_id=conversation_id,
+                style=style,
+            )
+    except SynapIntegrationError:
+        if on_error == "raise":
+            raise
+        return ""
+    if not getattr(response, "available", False):
+        return ""
+    formatted = getattr(response, "formatted_context", None)
+    return (formatted or "").strip()
+
+
+def _compose(
+    st_block: str,
+    user_system: str,
+    preamble_open: Optional[str],
+    preamble_close: Optional[str],
+) -> str:
+    parts = []
+    st_block = (st_block or "").strip()
+    user_system = (user_system or "").strip()
+    if st_block:
+        if preamble_open and preamble_close:
+            parts.append(f"{preamble_open}\n{st_block}\n{preamble_close}")
+        else:
+            parts.append(st_block)
+    if user_system:
+        parts.append(user_system)
+    return "\n\n".join(parts)
+
+
+def synap_st_instructions(
+    sdk: MaximemSynapSDK,
+    conversation_id: str,
+    *,
+    system: str = "",
+    style: str = "narrative",
+    preamble_open: Optional[str] = _DEFAULT_OPEN,
+    preamble_close: Optional[str] = _DEFAULT_CLOSE,
+    on_error: _OnError = "fallback",
+) -> Callable[[Any, Any], Awaitable[str]]:
+    """Return an async ``instructions`` callable for Smolagents.
+
+    The callable matches Smolagents' expected signature
+    ``async (context, agent) -> str``. Both arguments are ignored — we
+    use the explicitly-bound ``conversation_id`` rather than inferring
+    from any framework-internal session.
+
+    Args:
+        sdk: Initialised :class:`MaximemSynapSDK`.
+        conversation_id: Synap conversation ID. **Required.**
+        system: Your own agent instructions; ST is prepended above.
+        style: One of ``"structured" | "narrative" | "bullet_points"``.
+        preamble_open / preamble_close: Wrapping tags; pass ``None`` for
+            both to drop the tags.
+        on_error: ``"fallback"`` (default) returns bare ``system`` on
+            SDK failure; ``"raise"`` propagates :class:`SynapIntegrationError`.
+
+    Example::
+
+        # from Smolagents import Agent  # example
+        from maximem_synap import MaximemSynapSDK
+        from synap_smolagents import synap_st_instructions
+
+        sdk = MaximemSynapSDK(api_key="sk-...")
+        agent = Agent(
+            name="support",
+            instructions=synap_st_instructions(
+                sdk,
+                conversation_id="conv_abc",
+                system="You are a polite support agent.",
+            ),
+            tools=[...],
+        )
+    """
+    _validate_args(sdk, conversation_id, style, on_error, "synap_st_instructions")
+
+    async def _instructions(context: Any, agent: Any) -> str:  # noqa: ARG001 — framework signature
+        st_block = await _fetch_st_block(
+            sdk,
+            conversation_id,
+            style,
+            on_error,
+            site="synap_smolagents.synap_st_instructions",
+        )
+        return _compose(st_block, system, preamble_open, preamble_close)
+
+    _instructions.__name__ = "synap_st_instructions"
+    return _instructions
+
+
+__all__ = ["synap_st_instructions"]

--- a/packages/integrations/synap-smolagents/synap_smolagents/tools.py
+++ b/packages/integrations/synap-smolagents/synap_smolagents/tools.py
@@ -1,0 +1,79 @@
+"""Synap tools for Smolagents.
+
+Provides memory search/store callables for Smolagents agents.
+SDK failures are wrapped in :class:`SynapIntegrationError`.
+"""
+
+import logging
+from typing import Optional
+
+from maximem_synap import MaximemSynapSDK
+from synap_integrations_common import wrap_sdk_errors_async
+
+logger = logging.getLogger(__name__)
+
+
+def create_search_tool(
+    sdk: MaximemSynapSDK,
+    user_id: str,
+    customer_id: str = "",
+    conversation_id: Optional[str] = None,
+):
+    """Create a memory search callable for Smolagents.
+
+    Example::
+
+        search_fn = create_search_tool(sdk, user_id="u1")
+        # Wire into your Smolagents agent: Tool(search_memory, name='search_memory')
+    """
+    if sdk is None:
+        raise ValueError("create_search_tool requires a non-None sdk")
+    if not user_id:
+        raise ValueError("create_search_tool requires a non-empty user_id")
+
+    async def search_memory(query: str) -> str:
+        """Search the user's memory for relevant context."""
+        async with wrap_sdk_errors_async(
+            "smolagents.search_memory",
+            logger,
+            user_id=user_id,
+        ):
+            response = await sdk.fetch(
+                conversation_id=conversation_id,
+                user_id=user_id,
+                customer_id=customer_id or None,
+                search_query=[query],
+                mode="accurate",
+                include_conversation_context=False,
+            )
+        return response.formatted_context or "No relevant memories found."
+
+    return search_memory
+
+
+def create_store_tool(
+    sdk: MaximemSynapSDK,
+    user_id: str,
+    customer_id: str = "",
+):
+    """Create a memory store callable for Smolagents."""
+    if sdk is None:
+        raise ValueError("create_store_tool requires a non-None sdk")
+    if not user_id:
+        raise ValueError("create_store_tool requires a non-empty user_id")
+
+    async def store_memory(content: str) -> str:
+        """Store important information about the user for future reference."""
+        async with wrap_sdk_errors_async(
+            "smolagents.store_memory",
+            logger,
+            user_id=user_id,
+        ):
+            result = await sdk.memories.create(
+                document=content,
+                user_id=user_id,
+                customer_id=customer_id,
+            )
+        return f"Memory stored (ingestion_id: {result.ingestion_id})"
+
+    return store_memory

--- a/packages/integrations/synap-smolagents/tests/conftest.py
+++ b/packages/integrations/synap-smolagents/tests/conftest.py
@@ -1,0 +1,26 @@
+"""Pytest conftest for synap-openai-agents tests.
+
+Re-exports fixtures and factories from the shared harness so every test file
+can rely on a single, canonical source of truth.
+"""
+
+import sys
+import os
+
+# Ensure local packages are importable when running from repo root.
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../synap/sdk/python"))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(
+    0, os.path.join(os.path.dirname(__file__), "../../synap-integrations-common")
+)
+
+from synap_integrations_common.testing import (  # noqa: F401
+    mock_sdk,
+    failing_sdk,
+    make_fact,
+    make_preference,
+    make_episode,
+    make_emotion,
+    make_temporal_event,
+    make_unified_response,
+)

--- a/packages/integrations/synap-smolagents/tests/test_short_term.py
+++ b/packages/integrations/synap-smolagents/tests/test_short_term.py
@@ -1,0 +1,376 @@
+"""Tests for synap_smolagents.short_term — synap_st_instructions.
+
+Covers:
+- Construction validation (sdk=None, empty/whitespace conversation_id, unknown style,
+  invalid on_error)
+- Happy paths: ST block present, preamble wrapping, style forwarding, all 3 styles accepted
+- Empty-ST safety: unavailable flag, None formatted_context, empty string
+- Error policies: fallback (on_error="fallback") returns bare system, raise propagates
+  SynapIntegrationError
+- Callable contract: returned value is an async callable accepting (context, agent)
+- Harness: failing_sdk fixture
+- Public surface: __all__ exports
+"""
+
+from __future__ import annotations
+
+import inspect
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from synap_smolagents.short_term import synap_st_instructions
+from synap_integrations_common import SynapIntegrationError
+
+
+# ---------------------------------------------------------------------------
+# Local helpers — minimal, keep tests readable
+# ---------------------------------------------------------------------------
+
+
+def _make_response(formatted: str | None, available: bool = True):
+    resp = MagicMock()
+    resp.available = available
+    resp.formatted_context = formatted
+    return resp
+
+
+def _fake_sdk(
+    formatted: str | None = "User prefers concise replies.", available: bool = True
+):
+    sdk = MagicMock()
+    sdk.conversation.context.get_context_for_prompt = AsyncMock(
+        return_value=_make_response(formatted, available)
+    )
+    return sdk
+
+
+# ---------------------------------------------------------------------------
+# Construction validation
+# ---------------------------------------------------------------------------
+
+
+class TestValidation:
+    def test_requires_sdk(self):
+        with pytest.raises(ValueError, match="non-None sdk"):
+            synap_st_instructions(None, "conv_abc")  # type: ignore[arg-type]
+
+    def test_requires_nonempty_conversation_id(self):
+        sdk = _fake_sdk()
+        with pytest.raises(ValueError, match="non-empty conversation_id"):
+            synap_st_instructions(sdk, "")
+
+    def test_rejects_whitespace_only_conversation_id(self):
+        sdk = _fake_sdk()
+        with pytest.raises(ValueError, match="non-empty conversation_id"):
+            synap_st_instructions(sdk, "   ")
+
+    def test_rejects_unknown_style(self):
+        sdk = _fake_sdk()
+        with pytest.raises(ValueError, match="unsupported style"):
+            synap_st_instructions(sdk, "conv_abc", style="poetic")
+
+    def test_rejects_invalid_on_error(self):
+        sdk = _fake_sdk()
+        with pytest.raises(ValueError, match="on_error"):
+            synap_st_instructions(sdk, "conv_abc", on_error="ignore")  # type: ignore[arg-type]
+
+    def test_accepts_all_supported_styles(self):
+        sdk = _fake_sdk()
+        for style in ("structured", "narrative", "bullet_points"):
+            # Should NOT raise
+            fn = synap_st_instructions(sdk, "conv_abc", style=style)
+            assert callable(fn), f"should return callable for style={style!r}"
+
+
+# ---------------------------------------------------------------------------
+# Callable contract
+# ---------------------------------------------------------------------------
+
+
+class TestCallableContract:
+    def test_returns_async_callable(self):
+        sdk = _fake_sdk()
+        fn = synap_st_instructions(sdk, "conv_abc")
+        assert callable(fn)
+        assert inspect.iscoroutinefunction(fn), "instructions must be async"
+
+    def test_callable_is_named(self):
+        sdk = _fake_sdk()
+        fn = synap_st_instructions(sdk, "conv_abc")
+        assert fn.__name__ == "synap_st_instructions"
+
+    @pytest.mark.asyncio
+    async def test_accepts_two_positional_args(self):
+        """OpenAI Agents calls instructions(context, agent) — both args must be accepted."""
+        sdk = _fake_sdk(formatted="ctx")
+        fn = synap_st_instructions(sdk, "conv_abc", system="sys")
+        # Should not raise with two MagicMock positional arguments
+        result = await fn(MagicMock(), MagicMock())
+        assert isinstance(result, str)
+
+
+# ---------------------------------------------------------------------------
+# Happy paths — ST present
+# ---------------------------------------------------------------------------
+
+
+class TestHappyPath:
+    @pytest.mark.asyncio
+    async def test_returns_combined_instructions_with_default_preamble(self):
+        sdk = _fake_sdk(formatted="User likes Markdown.")
+        instr = synap_st_instructions(sdk, "conv_abc", system="You are a coding agent.")
+        result = await instr(MagicMock(), MagicMock())
+        assert "<synap_short_term_context>" in result
+        assert "User likes Markdown." in result
+        assert "</synap_short_term_context>" in result
+        assert "You are a coding agent." in result
+        # ST block must appear before user system text
+        assert result.index("User likes Markdown") < result.index("coding agent")
+
+    @pytest.mark.asyncio
+    async def test_passes_conversation_id_and_style_to_sdk(self):
+        sdk = _fake_sdk()
+        instr = synap_st_instructions(
+            sdk, "conv_xyz", style="bullet_points", system="X"
+        )
+        await instr(MagicMock(), MagicMock())
+        sdk.conversation.context.get_context_for_prompt.assert_awaited_once_with(
+            conversation_id="conv_xyz",
+            style="bullet_points",
+        )
+
+    @pytest.mark.asyncio
+    async def test_default_style_is_narrative(self):
+        sdk = _fake_sdk()
+        instr = synap_st_instructions(sdk, "conv_abc", system="X")
+        await instr(MagicMock(), MagicMock())
+        sdk.conversation.context.get_context_for_prompt.assert_awaited_once_with(
+            conversation_id="conv_abc",
+            style="narrative",
+        )
+
+    @pytest.mark.asyncio
+    async def test_custom_preamble_tags(self):
+        sdk = _fake_sdk(formatted="X")
+        instr = synap_st_instructions(
+            sdk,
+            "conv_abc",
+            system="sys",
+            preamble_open="[BEGIN]",
+            preamble_close="[END]",
+        )
+        out = await instr(MagicMock(), MagicMock())
+        assert "[BEGIN]" in out
+        assert "[END]" in out
+        assert "<synap_short_term_context>" not in out
+
+    @pytest.mark.asyncio
+    async def test_no_preamble_raw_concat(self):
+        """When both preamble tags are None, ST and system are joined with double newline."""
+        sdk = _fake_sdk(formatted="raw st")
+        instr = synap_st_instructions(
+            sdk,
+            "conv_abc",
+            system="user sys",
+            preamble_open=None,
+            preamble_close=None,
+        )
+        out = await instr(MagicMock(), MagicMock())
+        assert out == "raw st\n\nuser sys"
+
+    @pytest.mark.asyncio
+    async def test_st_only_no_system(self):
+        """When system is empty, only the ST block (with preamble) is returned."""
+        sdk = _fake_sdk(formatted="context block")
+        instr = synap_st_instructions(sdk, "conv_abc", system="")
+        out = await instr(MagicMock(), MagicMock())
+        assert "context block" in out
+        assert "<synap_short_term_context>" in out
+
+    @pytest.mark.asyncio
+    async def test_structured_style_forwarded(self):
+        sdk = _fake_sdk()
+        instr = synap_st_instructions(sdk, "conv_abc", style="structured")
+        await instr(MagicMock(), MagicMock())
+        sdk.conversation.context.get_context_for_prompt.assert_awaited_once_with(
+            conversation_id="conv_abc",
+            style="structured",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Empty / unavailable ST
+# ---------------------------------------------------------------------------
+
+
+class TestEmptyST:
+    @pytest.mark.asyncio
+    async def test_unavailable_returns_user_system_only(self):
+        sdk = _fake_sdk(formatted=None, available=False)
+        instr = synap_st_instructions(sdk, "conv_abc", system="You are friendly.")
+        out = await instr(MagicMock(), MagicMock())
+        assert out == "You are friendly."
+
+    @pytest.mark.asyncio
+    async def test_unavailable_empty_system_returns_empty_string(self):
+        sdk = _fake_sdk(formatted=None, available=False)
+        instr = synap_st_instructions(sdk, "conv_abc", system="")
+        out = await instr(MagicMock(), MagicMock())
+        assert out == ""
+
+    @pytest.mark.asyncio
+    async def test_none_formatted_context_with_available_true_treated_as_empty(self):
+        """Even if available=True, a None formatted_context yields no ST block."""
+        sdk = _fake_sdk(formatted=None, available=True)
+        instr = synap_st_instructions(sdk, "conv_abc", system="sys")
+        out = await instr(MagicMock(), MagicMock())
+        assert out == "sys"
+        assert "<synap_short_term_context>" not in out
+
+    @pytest.mark.asyncio
+    async def test_empty_string_formatted_context_treated_as_empty(self):
+        sdk = _fake_sdk(formatted="", available=True)
+        instr = synap_st_instructions(sdk, "conv_abc", system="sys")
+        out = await instr(MagicMock(), MagicMock())
+        assert out == "sys"
+
+    @pytest.mark.asyncio
+    async def test_whitespace_only_formatted_context_treated_as_empty(self):
+        sdk = _fake_sdk(formatted="   ", available=True)
+        instr = synap_st_instructions(sdk, "conv_abc", system="sys")
+        out = await instr(MagicMock(), MagicMock())
+        assert out == "sys"
+
+
+# ---------------------------------------------------------------------------
+# Error policies
+# ---------------------------------------------------------------------------
+
+
+class TestErrorPolicies:
+    @pytest.mark.asyncio
+    async def test_fallback_on_sdk_failure_returns_user_system(self):
+        sdk = MagicMock()
+        sdk.conversation.context.get_context_for_prompt = AsyncMock(
+            side_effect=RuntimeError("sdk boom")
+        )
+        instr = synap_st_instructions(
+            sdk, "conv_abc", system="Stay calm.", on_error="fallback"
+        )
+        out = await instr(MagicMock(), MagicMock())
+        assert out == "Stay calm."
+
+    @pytest.mark.asyncio
+    async def test_fallback_empty_system_returns_empty_string(self):
+        sdk = MagicMock()
+        sdk.conversation.context.get_context_for_prompt = AsyncMock(
+            side_effect=RuntimeError("sdk boom")
+        )
+        instr = synap_st_instructions(sdk, "conv_abc", system="", on_error="fallback")
+        out = await instr(MagicMock(), MagicMock())
+        assert out == ""
+
+    @pytest.mark.asyncio
+    async def test_raise_propagates_synap_integration_error(self):
+        sdk = MagicMock()
+        sdk.conversation.context.get_context_for_prompt = AsyncMock(
+            side_effect=RuntimeError("sdk boom")
+        )
+        instr = synap_st_instructions(sdk, "conv_abc", system="X", on_error="raise")
+        with pytest.raises(SynapIntegrationError):
+            await instr(MagicMock(), MagicMock())
+
+    @pytest.mark.asyncio
+    async def test_raise_chains_original_cause(self):
+        original = RuntimeError("original sdk error")
+        sdk = MagicMock()
+        sdk.conversation.context.get_context_for_prompt = AsyncMock(
+            side_effect=original
+        )
+        instr = synap_st_instructions(sdk, "conv_abc", system="X", on_error="raise")
+        with pytest.raises(SynapIntegrationError) as exc_info:
+            await instr(MagicMock(), MagicMock())
+        assert exc_info.value.__cause__ is original
+
+    @pytest.mark.asyncio
+    async def test_synap_integration_error_passthrough_on_raise(self):
+        """A SynapIntegrationError raised by the SDK should propagate without double-wrapping."""
+        sdk = MagicMock()
+        original = SynapIntegrationError("op", "direct error")
+        sdk.conversation.context.get_context_for_prompt = AsyncMock(
+            side_effect=original
+        )
+        instr = synap_st_instructions(sdk, "conv_abc", system="X", on_error="raise")
+        with pytest.raises(SynapIntegrationError) as exc_info:
+            await instr(MagicMock(), MagicMock())
+        # Should be exactly the original instance (not a new wrapper)
+        assert exc_info.value is original
+
+
+# ---------------------------------------------------------------------------
+# failing_sdk harness fixture
+# ---------------------------------------------------------------------------
+
+
+class TestFailingSdkHarness:
+    @pytest.mark.asyncio
+    async def test_fallback_with_failing_sdk(self, failing_sdk):
+        """failing_sdk triggers fallback; system text is returned unmodified."""
+        instr = synap_st_instructions(
+            failing_sdk, "conv_abc", system="fallback text", on_error="fallback"
+        )
+        out = await instr(MagicMock(), MagicMock())
+        assert out == "fallback text"
+
+    @pytest.mark.asyncio
+    async def test_raise_with_failing_sdk_surfaces_error(self, failing_sdk):
+        """failing_sdk with on_error='raise' must propagate as SynapIntegrationError."""
+        instr = synap_st_instructions(
+            failing_sdk, "conv_abc", system="X", on_error="raise"
+        )
+        with pytest.raises(SynapIntegrationError):
+            await instr(MagicMock(), MagicMock())
+
+
+# ---------------------------------------------------------------------------
+# mock_sdk harness fixture
+# ---------------------------------------------------------------------------
+
+
+class TestMockSdkHarness:
+    @pytest.mark.asyncio
+    async def test_mock_sdk_happy_path(self, mock_sdk):
+        """mock_sdk pre-wires get_context_for_prompt → returns a combined instructions string."""
+        instr = synap_st_instructions(
+            mock_sdk, "conv_abc", system="Agent system prompt."
+        )
+        out = await instr(MagicMock(), MagicMock())
+        assert isinstance(out, str)
+        # Combined output contains ST and user system text
+        assert "Agent system prompt." in out
+
+
+# ---------------------------------------------------------------------------
+# Public surface
+# ---------------------------------------------------------------------------
+
+
+class TestPublicSurface:
+    def test_module_exports_synap_st_instructions(self):
+        import synap_smolagents
+
+        assert hasattr(synap_smolagents, "synap_st_instructions")
+        assert "synap_st_instructions" in synap_smolagents.__all__
+
+    def test_create_search_tool_exported(self):
+        import synap_smolagents
+
+        assert hasattr(synap_smolagents, "create_search_tool")
+        assert "create_search_tool" in synap_smolagents.__all__
+
+    def test_create_store_tool_exported(self):
+        import synap_smolagents
+
+        assert hasattr(synap_smolagents, "create_store_tool")
+        assert "create_store_tool" in synap_smolagents.__all__

--- a/packages/integrations/synap-smolagents/tests/test_tools.py
+++ b/packages/integrations/synap-smolagents/tests/test_tools.py
@@ -1,0 +1,324 @@
+"""Tests for synap_smolagents.tools — create_search_tool / create_store_tool.
+
+Documented error-handling contract (from tools.py / wrap_sdk_errors_async):
+- Both factory functions validate sdk != None and user_id != "".
+- The returned async callables wrap SDK errors as SynapIntegrationError.
+- Callers (agent frameworks / test harnesses) decide how to handle the error.
+
+Covers:
+- Construction validation: sdk=None, empty user_id for both factories
+- search_memory happy paths: result forwarding, kwargs forwarded to sdk.fetch,
+  None/empty formatted_context fallback sentinel, conversation_id threading,
+  customer_id threading
+- store_memory happy paths: ingestion_id in return, kwargs forwarded to
+  sdk.memories.create, customer_id pass-through
+- Failure paths: SynapIntegrationError raised on SDK failure (both tools)
+- failing_sdk harness fixture
+- Public surface exports
+"""
+
+from __future__ import annotations
+
+import inspect
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from synap_smolagents.tools import create_search_tool, create_store_tool
+from synap_integrations_common import SynapIntegrationError
+
+
+# ---------------------------------------------------------------------------
+# Local helper: minimal SDK mock (unit-level, independent of shared harness)
+# ---------------------------------------------------------------------------
+
+
+def _sdk(fetch_return=None, create_return=None):
+    sdk = MagicMock()
+    sdk.fetch = AsyncMock(
+        return_value=fetch_return or MagicMock(formatted_context="ctx")
+    )
+    sdk.memories = MagicMock()
+    sdk.memories.create = AsyncMock(
+        return_value=create_return or MagicMock(ingestion_id="ing-001")
+    )
+    return sdk
+
+
+# ---------------------------------------------------------------------------
+# Public surface
+# ---------------------------------------------------------------------------
+
+
+def test_package_exports_create_search_tool():
+    from synap_smolagents import create_search_tool
+
+    assert create_search_tool is not None
+
+
+def test_package_exports_create_store_tool():
+    from synap_smolagents import create_store_tool
+
+    assert create_store_tool is not None
+
+
+# ---------------------------------------------------------------------------
+# create_search_tool — construction validation
+# ---------------------------------------------------------------------------
+
+
+class TestCreateSearchToolValidation:
+    def test_raises_on_none_sdk(self):
+        with pytest.raises(ValueError, match="non-None sdk"):
+            create_search_tool(None, user_id="u1")  # type: ignore[arg-type]
+
+    def test_raises_on_empty_user_id(self):
+        sdk = _sdk()
+        with pytest.raises(ValueError, match="non-empty user_id"):
+            create_search_tool(sdk, user_id="")
+
+    def test_returns_async_callable(self):
+        sdk = _sdk()
+        fn = create_search_tool(sdk, user_id="u1")
+        assert callable(fn)
+        assert inspect.iscoroutinefunction(fn), "search_memory must be async"
+
+
+# ---------------------------------------------------------------------------
+# create_search_tool — happy paths
+# ---------------------------------------------------------------------------
+
+
+class TestSearchToolHappyPath:
+    @pytest.mark.asyncio
+    async def test_returns_formatted_context(self):
+        sdk = _sdk(fetch_return=MagicMock(formatted_context="User likes tea"))
+        search = create_search_tool(sdk, user_id="u1")
+        result = await search(query="tea")
+        assert result == "User likes tea"
+
+    @pytest.mark.asyncio
+    async def test_forwards_query_as_list(self):
+        sdk = _sdk()
+        search = create_search_tool(sdk, user_id="u1")
+        await search(query="coffee preferences")
+        sdk.fetch.assert_awaited_once()
+        assert sdk.fetch.call_args.kwargs["search_query"] == ["coffee preferences"]
+
+    @pytest.mark.asyncio
+    async def test_forwards_user_id(self):
+        sdk = _sdk()
+        search = create_search_tool(sdk, user_id="user-42")
+        await search(query="q")
+        assert sdk.fetch.call_args.kwargs["user_id"] == "user-42"
+
+    @pytest.mark.asyncio
+    async def test_mode_is_accurate(self):
+        sdk = _sdk()
+        search = create_search_tool(sdk, user_id="u1")
+        await search(query="q")
+        assert sdk.fetch.call_args.kwargs["mode"] == "accurate"
+
+    @pytest.mark.asyncio
+    async def test_include_conversation_context_is_false(self):
+        sdk = _sdk()
+        search = create_search_tool(sdk, user_id="u1")
+        await search(query="q")
+        assert sdk.fetch.call_args.kwargs["include_conversation_context"] is False
+
+    @pytest.mark.asyncio
+    async def test_none_formatted_context_returns_sentinel(self):
+        sdk = _sdk(fetch_return=MagicMock(formatted_context=None))
+        search = create_search_tool(sdk, user_id="u1")
+        result = await search(query="unknown")
+        assert result == "No relevant memories found."
+
+    @pytest.mark.asyncio
+    async def test_empty_string_formatted_context_returns_sentinel(self):
+        sdk = _sdk(fetch_return=MagicMock(formatted_context=""))
+        search = create_search_tool(sdk, user_id="u1")
+        result = await search(query="unknown")
+        assert result == "No relevant memories found."
+
+    @pytest.mark.asyncio
+    async def test_conversation_id_forwarded_when_provided(self):
+        sdk = _sdk()
+        search = create_search_tool(sdk, user_id="u1", conversation_id="conv-99")
+        await search(query="q")
+        assert sdk.fetch.call_args.kwargs["conversation_id"] == "conv-99"
+
+    @pytest.mark.asyncio
+    async def test_conversation_id_none_when_not_provided(self):
+        sdk = _sdk()
+        search = create_search_tool(sdk, user_id="u1")
+        await search(query="q")
+        # None or not present — depends on implementation; either is acceptable
+        kwargs = sdk.fetch.call_args.kwargs
+        assert kwargs.get("conversation_id") is None
+
+    @pytest.mark.asyncio
+    async def test_customer_id_forwarded(self):
+        sdk = _sdk()
+        search = create_search_tool(sdk, user_id="u1", customer_id="cust-7")
+        await search(query="q")
+        kwargs = sdk.fetch.call_args.kwargs
+        # customer_id='' maps to None internally; non-empty is forwarded as-is
+        assert kwargs.get("customer_id") == "cust-7"
+
+    @pytest.mark.asyncio
+    async def test_empty_customer_id_coerced_to_none(self):
+        """Empty customer_id is coerced to None before sdk.fetch per product code."""
+        sdk = _sdk()
+        search = create_search_tool(sdk, user_id="u1", customer_id="")
+        await search(query="q")
+        kwargs = sdk.fetch.call_args.kwargs
+        assert kwargs.get("customer_id") is None
+
+
+# ---------------------------------------------------------------------------
+# create_search_tool — failure paths
+# ---------------------------------------------------------------------------
+
+
+class TestSearchToolFailurePath:
+    @pytest.mark.asyncio
+    async def test_raises_synap_integration_error_on_sdk_failure(self):
+        sdk = _sdk()
+        sdk.fetch = AsyncMock(side_effect=RuntimeError("sdk boom"))
+        search = create_search_tool(sdk, user_id="u1")
+        with pytest.raises(SynapIntegrationError):
+            await search(query="any query")
+
+    @pytest.mark.asyncio
+    async def test_synap_integration_error_chains_original_cause(self):
+        original = RuntimeError("original sdk error")
+        sdk = _sdk()
+        sdk.fetch = AsyncMock(side_effect=original)
+        search = create_search_tool(sdk, user_id="u1")
+        with pytest.raises(SynapIntegrationError) as exc_info:
+            await search(query="q")
+        assert exc_info.value.__cause__ is original
+
+    @pytest.mark.asyncio
+    async def test_failing_sdk_search_raises(self, failing_sdk):
+        """Shared failing_sdk fixture — get_context_for_prompt raises RuntimeError."""
+        # failing_sdk wires sdk.fetch to raise; so create_search_tool must propagate
+        search = create_search_tool(failing_sdk, user_id="u1")
+        with pytest.raises(SynapIntegrationError):
+            await search(query="anything")
+
+
+# ---------------------------------------------------------------------------
+# create_store_tool — construction validation
+# ---------------------------------------------------------------------------
+
+
+class TestCreateStoreToolValidation:
+    def test_raises_on_none_sdk(self):
+        with pytest.raises(ValueError, match="non-None sdk"):
+            create_store_tool(None, user_id="u1")  # type: ignore[arg-type]
+
+    def test_raises_on_empty_user_id(self):
+        sdk = _sdk()
+        with pytest.raises(ValueError, match="non-empty user_id"):
+            create_store_tool(sdk, user_id="")
+
+    def test_returns_async_callable(self):
+        sdk = _sdk()
+        fn = create_store_tool(sdk, user_id="u1")
+        assert callable(fn)
+        assert inspect.iscoroutinefunction(fn), "store_memory must be async"
+
+
+# ---------------------------------------------------------------------------
+# create_store_tool — happy paths
+# ---------------------------------------------------------------------------
+
+
+class TestStoreToolHappyPath:
+    @pytest.mark.asyncio
+    async def test_returns_string_with_ingestion_id(self):
+        sdk = _sdk(create_return=MagicMock(ingestion_id="ing-123"))
+        store = create_store_tool(sdk, user_id="u1")
+        result = await store(content="User prefers dark mode")
+        assert "ing-123" in result
+
+    @pytest.mark.asyncio
+    async def test_returns_string(self):
+        sdk = _sdk()
+        store = create_store_tool(sdk, user_id="u1")
+        result = await store(content="some content")
+        assert isinstance(result, str)
+
+    @pytest.mark.asyncio
+    async def test_forwards_document_to_memories_create(self):
+        sdk = _sdk()
+        store = create_store_tool(sdk, user_id="u1")
+        await store(content="User prefers dark mode")
+        sdk.memories.create.assert_awaited_once()
+        kwargs = sdk.memories.create.call_args.kwargs
+        assert kwargs["document"] == "User prefers dark mode"
+
+    @pytest.mark.asyncio
+    async def test_forwards_user_id_to_memories_create(self):
+        sdk = _sdk()
+        store = create_store_tool(sdk, user_id="user-99")
+        await store(content="some info")
+        kwargs = sdk.memories.create.call_args.kwargs
+        assert kwargs["user_id"] == "user-99"
+
+    @pytest.mark.asyncio
+    async def test_forwards_customer_id_to_memories_create(self):
+        sdk = _sdk()
+        store = create_store_tool(sdk, user_id="u1", customer_id="cust-42")
+        await store(content="info")
+        kwargs = sdk.memories.create.call_args.kwargs
+        assert kwargs["customer_id"] == "cust-42"
+
+    @pytest.mark.asyncio
+    async def test_empty_customer_id_forwarded_as_empty_string(self):
+        """Default customer_id='' is passed through to memories.create unchanged."""
+        sdk = _sdk()
+        store = create_store_tool(sdk, user_id="u1")
+        await store(content="info")
+        kwargs = sdk.memories.create.call_args.kwargs
+        assert kwargs["customer_id"] == ""
+
+    @pytest.mark.asyncio
+    async def test_mock_sdk_store_happy_path(self, mock_sdk):
+        """Shared mock_sdk harness: memories.create pre-wired to return ingestion_id=ing-001."""
+        store = create_store_tool(mock_sdk, user_id="u1")
+        result = await store(content="remember this")
+        assert "ing-001" in result
+
+
+# ---------------------------------------------------------------------------
+# create_store_tool — failure paths
+# ---------------------------------------------------------------------------
+
+
+class TestStoreToolFailurePath:
+    @pytest.mark.asyncio
+    async def test_raises_synap_integration_error_on_sdk_failure(self):
+        sdk = _sdk()
+        sdk.memories.create = AsyncMock(side_effect=RuntimeError("sdk boom"))
+        store = create_store_tool(sdk, user_id="u1")
+        with pytest.raises(SynapIntegrationError):
+            await store(content="content to store")
+
+    @pytest.mark.asyncio
+    async def test_synap_integration_error_chains_original_cause(self):
+        original = RuntimeError("original error")
+        sdk = _sdk()
+        sdk.memories.create = AsyncMock(side_effect=original)
+        store = create_store_tool(sdk, user_id="u1")
+        with pytest.raises(SynapIntegrationError) as exc_info:
+            await store(content="content")
+        assert exc_info.value.__cause__ is original
+
+    @pytest.mark.asyncio
+    async def test_failing_sdk_store_raises(self, failing_sdk):
+        """Shared failing_sdk fixture — sdk.memories.create raises RuntimeError."""
+        store = create_store_tool(failing_sdk, user_id="u1")
+        with pytest.raises(SynapIntegrationError):
+            await store(content="anything")


### PR DESCRIPTION
## Summary

- Adds five new Synap framework integrations that were not previously in the repo:
  - **DSPy** (`maximem-synap-dspy`) — Stanford's declarative LLM programming framework
  - **Smolagents** (`maximem-synap-smolagents`) — Hugging Face lightweight code/tool agents
  - **Camel-AI** (`maximem-synap-camel`) — multi-agent communication and society framework
  - **Marvin** (`maximem-synap-marvin`) — Prefect's AI toolkit for structured agent workflows
  - **Mirascope** (`maximem-synap-mirascope`) — provider-agnostic LLM toolkit with tool decorators
- Each package includes `create_search_tool`, `create_store_tool`, and `synap_st_instructions` following the existing OpenAI Agents integration pattern
- Updates root README integration table and framework banner

## Test plan

- [x] `pytest packages/integrations/synap-dspy/tests/` — 64 passed
- [x] `pytest packages/integrations/synap-smolagents/tests/` — 64 passed
- [x] `pytest packages/integrations/synap-camel/tests/` — 64 passed
- [x] `pytest packages/integrations/synap-marvin/tests/` — 64 passed
- [x] `pytest packages/integrations/synap-mirascope/tests/` — 64 passed
- [x] `ruff check` and `ruff format --check` on all five packages — clean