### PR TITLE
feat(sdk): add precision_level fetch parameter (high|medium)

### DIFF
--- a/packages/sdks/maximem-synap-js/src/synap-client.js
+++ b/packages/sdks/maximem-synap-js/src/synap-client.js
@@ -267,7 +267,7 @@ class SynapClient {
     return normalizeGetMemoriesResult(await this.bridge.call('get_memories', params));
   }
 
-  async fetchUserContext({ userId, customerId, conversationId, searchQuery, maxResults = 10, types, mode }) {
+  async fetchUserContext({ userId, customerId, conversationId, searchQuery, maxResults = 10, types, mode, precisionLevel }) {
     this.#assert(userId, 'userId is required');
     this.#assertArray(searchQuery, 'searchQuery must be an array when provided');
     this.#assertArray(types, 'types must be an array when provided');
@@ -278,11 +278,12 @@ class SynapClient {
     if (searchQuery !== undefined) params.search_query = searchQuery;
     if (types !== undefined) params.types = types;
     if (mode !== undefined) params.mode = mode;
+    if (precisionLevel !== undefined) params.precision_level = precisionLevel;
 
     return normalizeContextResponse(await this.bridge.call('fetch_user_context', params));
   }
 
-  async fetchCustomerContext({ customerId, conversationId, searchQuery, maxResults = 10, types, mode }) {
+  async fetchCustomerContext({ customerId, conversationId, searchQuery, maxResults = 10, types, mode, precisionLevel }) {
     this.#assert(customerId, 'customerId is required');
     this.#assertArray(searchQuery, 'searchQuery must be an array when provided');
     this.#assertArray(types, 'types must be an array when provided');
@@ -292,11 +293,12 @@ class SynapClient {
     if (searchQuery !== undefined) params.search_query = searchQuery;
     if (types !== undefined) params.types = types;
     if (mode !== undefined) params.mode = mode;
+    if (precisionLevel !== undefined) params.precision_level = precisionLevel;
 
     return normalizeContextResponse(await this.bridge.call('fetch_customer_context', params));
   }
 
-  async fetchClientContext({ conversationId, searchQuery, maxResults = 10, types, mode } = {}) {
+  async fetchClientContext({ conversationId, searchQuery, maxResults = 10, types, mode, precisionLevel } = {}) {
     this.#assertArray(searchQuery, 'searchQuery must be an array when provided');
     this.#assertArray(types, 'types must be an array when provided');
 
@@ -305,6 +307,7 @@ class SynapClient {
     if (searchQuery !== undefined) params.search_query = searchQuery;
     if (types !== undefined) params.types = types;
     if (mode !== undefined) params.mode = mode;
+    if (precisionLevel !== undefined) params.precision_level = precisionLevel;
 
     return normalizeContextResponse(await this.bridge.call('fetch_client_context', params));
   }

--- a/packages/sdks/maximem-synap/maximem_synap/_version.py
+++ b/packages/sdks/maximem-synap/maximem_synap/_version.py
@@ -1,3 +1,3 @@
 """Version information for MaximemSynap SDK."""
 
-__version__ = "0.2.6"
+__version__ = "0.3.0"

--- a/packages/sdks/maximem-synap/maximem_synap/facade/controllers.py
+++ b/packages/sdks/maximem-synap/maximem_synap/facade/controllers.py
@@ -54,6 +54,7 @@ class ConversationContextController:
         max_results: int = 10,
         types: Optional[List["ContextType"]] = None,
         mode: str = "fast",
+        precision_level: str = "high",
     ):
         """Fetch context for a conversation.
 
@@ -77,6 +78,7 @@ class ConversationContextController:
             "max_results": max_results,
             "types": [t.value for t in types] if types else ["all"],
             "mode": mode,
+            **({"precision_level": precision_level} if precision_level != "high" else {}),
         }
 
         result = await self._transport.post(
@@ -217,6 +219,7 @@ class UserContextController:
         max_results: int = 10,
         types: Optional[List["ContextType"]] = None,
         mode: str = "fast",
+        precision_level: str = "high",
     ):
         """Fetch context for a user.
 
@@ -242,6 +245,7 @@ class UserContextController:
             "max_results": max_results,
             "types": [t.value for t in types] if types else ["all"],
             "mode": mode,
+            **({"precision_level": precision_level} if precision_level != "high" else {}),
         }
 
         result = await self._transport.post(
@@ -280,6 +284,7 @@ class CustomerContextController:
         max_results: int = 10,
         types: Optional[List["ContextType"]] = None,
         mode: str = "fast",
+        precision_level: str = "high",
     ):
         """Fetch context for a customer.
 
@@ -305,6 +310,7 @@ class CustomerContextController:
             "max_results": max_results,
             "types": [t.value for t in types] if types else ["all"],
             "mode": mode,
+            **({"precision_level": precision_level} if precision_level != "high" else {}),
         }
 
         result = await self._transport.post(
@@ -342,6 +348,7 @@ class ClientContextController:
         max_results: int = 10,
         types: Optional[List["ContextType"]] = None,
         mode: str = "fast",
+        precision_level: str = "high",
     ):
         """Fetch context for a client (org-level).
 
@@ -365,6 +372,7 @@ class ClientContextController:
             "max_results": max_results,
             "types": [t.value for t in types] if types else ["all"],
             "mode": mode,
+            **({"precision_level": precision_level} if precision_level != "high" else {}),
         }
 
         result = await self._transport.post(

--- a/packages/sdks/maximem-synap/maximem_synap/sdk.py
+++ b/packages/sdks/maximem-synap/maximem_synap/sdk.py
@@ -522,6 +522,15 @@ def _tool_input_schema(scope: str, *, has_conversation_id: bool) -> Dict[str, An
                 "LLM-decomposed multi-query (~200-500ms). Default 'fast'."
             ),
         },
+        "precision_level": {
+            "type": "string",
+            "enum": ["high", "medium"],
+            "description": (
+                "Result filtering precision. 'high' (default) applies an extra "
+                "relevance-refinement pass; 'medium' skips it for faster, less "
+                "precisely filtered results (recall unaffected)."
+            ),
+        },
     }
     if scope == "conversation" and not has_conversation_id:
         # Closed-over conversation_id wasn't provided; LLM must supply per call.
@@ -558,6 +567,7 @@ async def _invoke_scope_fetch(
     max_results = int(call_args.get("max_results") or 10)
     types = call_args.get("types")
     mode = str(call_args.get("mode") or "fast")
+    precision_level = str(call_args.get("precision_level") or "high")
     call_conv_id = call_args.get("conversation_id") or conversation_id
 
     if scope == "unified":
@@ -569,6 +579,7 @@ async def _invoke_scope_fetch(
             max_results=max_results,
             types=types,
             mode=mode,
+            precision_level=precision_level,
         )
         return {
             "formatted_context": response.formatted_context,
@@ -585,6 +596,7 @@ async def _invoke_scope_fetch(
             max_results=max_results,
             types=types,
             mode=mode,
+            precision_level=precision_level,
             user_id=user_id,
         )
     elif scope == "user":
@@ -595,6 +607,7 @@ async def _invoke_scope_fetch(
             max_results=max_results,
             types=types,
             mode=mode,
+            precision_level=precision_level,
             customer_id=customer_id,
         )
     elif scope == "customer":
@@ -605,6 +618,7 @@ async def _invoke_scope_fetch(
             max_results=max_results,
             types=types,
             mode=mode,
+            precision_level=precision_level,
         )
     else:  # client
         response = await sdk.client.context.fetch(
@@ -613,6 +627,7 @@ async def _invoke_scope_fetch(
             max_results=max_results,
             types=types,
             mode=mode,
+            precision_level=precision_level,
         )
 
     return {
@@ -1153,6 +1168,7 @@ class MaximemSynapSDK:
         max_results: int = 20,
         types: Optional[List[str]] = None,
         mode: str = "fast",
+        precision_level: str = "high",
         include_conversation_context: bool = True,
         scopes: Optional[List[str]] = None,
         include_scope_labels: bool = False,
@@ -1175,6 +1191,8 @@ class MaximemSynapSDK:
             max_results: Max results per scope (total may be higher)
             types: Memory types to include (default: all)
             mode: Retrieval mode - "fast" (default) or "accurate"
+            precision_level: "high" (default) keeps the server-side relevance-refinement
+                pass; "medium" skips it for faster, less precisely filtered results.
             include_conversation_context: Include compacted history + recent messages
             scopes: Explicitly limit which scopes to query (e.g. ["user", "customer"]).
                     Default: all scopes for which an identifier is provided.
@@ -1220,6 +1238,7 @@ class MaximemSynapSDK:
                 max_results=max_results,
                 types=types,
                 mode=mode,
+                precision_level=precision_level,
                 user_id=user_id,
                 customer_id=customer_id,
             ))
@@ -1233,6 +1252,7 @@ class MaximemSynapSDK:
                 max_results=max_results,
                 types=types,
                 mode=mode,
+                precision_level=precision_level,
                 customer_id=customer_id,
             ))
             scope_labels.append("user")
@@ -1245,6 +1265,7 @@ class MaximemSynapSDK:
                 max_results=max_results,
                 types=types,
                 mode=mode,
+                precision_level=precision_level,
             ))
             scope_labels.append("customer")
 
@@ -1257,6 +1278,7 @@ class MaximemSynapSDK:
                     max_results=max_results,
                     types=types,
                     mode=mode,
+                    precision_level=precision_level,
                 ))
                 scope_labels.append("client")
 
@@ -1681,6 +1703,7 @@ class ConversationContextInterface:
         max_results: int = 10,
         types: Optional[List[str]] = None,
         mode: str = "fast",
+        precision_level: str = "high",
         user_id: Optional[str] = None,
         customer_id: Optional[str] = None,
     ) -> ContextResponse:
@@ -1692,6 +1715,8 @@ class ConversationContextInterface:
             max_results: Maximum results to return (default 10)
             types: Context types to include (default all)
             mode: Retrieval mode - "fast" (default) or "accurate"
+            precision_level: "high" (default) keeps the server-side relevance-refinement
+                pass; "medium" skips it for faster, less precisely filtered results.
                   - "fast": Direct query, low latency (~50-100ms)
                   - "accurate": LLM-enhanced queries, higher quality (~200-500ms)
             user_id: Optional external user id. Section 15 — passing this
@@ -1715,6 +1740,11 @@ class ConversationContextInterface:
         valid_modes = ("fast", "accurate")
         if mode not in valid_modes:
             raise InvalidInputError(f"Invalid mode '{mode}'. Must be one of: {valid_modes}")
+        valid_precision = ("high", "medium")
+        if precision_level not in valid_precision:
+            raise InvalidInputError(
+                f"Invalid precision_level '{precision_level}'. Must be one of: {valid_precision}"
+            )
 
         correlation_id = generate_correlation_id(self._sdk.instance_id)
         start_time = datetime.now(timezone.utc)
@@ -1726,6 +1756,7 @@ class ConversationContextInterface:
             "max_results": max_results,
             "types": types,
             "mode": mode,
+            "precision_level": precision_level,
         }
 
         # Check anticipation cache first (bundles pre-fetched via gRPC stream).
@@ -1796,6 +1827,8 @@ class ConversationContextInterface:
                     **({"user_id": user_id} if user_id else {}),
                     **({"customer_id": customer_id} if customer_id else {}),
                 }
+                if precision_level != "high":
+                    body["precision_level"] = precision_level
                 if skip_server_st:
                     body["include_conversation_context"] = False
                 result = await self._sdk._http_transport.post(
@@ -2299,6 +2332,7 @@ class UserContextInterface:
         max_results: int = 10,
         types: Optional[List[str]] = None,
         mode: str = "fast",
+        precision_level: str = "high",
         customer_id: Optional[str] = None,
     ) -> ContextResponse:
         """Fetch context for a user.
@@ -2310,6 +2344,8 @@ class UserContextInterface:
             max_results: Maximum results to return
             types: Context types to include
             mode: Retrieval mode - "fast" (default) or "accurate"
+            precision_level: "high" (default) keeps the server-side relevance-refinement
+                pass; "medium" skips it for faster, less precisely filtered results.
             customer_id: Optional customer ID. Required for B2B instances.
                 For B2C instances, this is auto-resolved from user_id.
 
@@ -2322,6 +2358,11 @@ class UserContextInterface:
         valid_modes = ("fast", "accurate")
         if mode not in valid_modes:
             raise InvalidInputError(f"Invalid mode '{mode}'. Must be one of: {valid_modes}")
+        valid_precision = ("high", "medium")
+        if precision_level not in valid_precision:
+            raise InvalidInputError(
+                f"Invalid precision_level '{precision_level}'. Must be one of: {valid_precision}"
+            )
 
         correlation_id = generate_correlation_id(self._sdk.instance_id)
         start_time = datetime.now(timezone.utc)
@@ -2333,6 +2374,7 @@ class UserContextInterface:
             "max_results": max_results,
             "types": types,
             "mode": mode,
+            "precision_level": precision_level,
         }
 
         # Check anticipation cache first (bundles pre-fetched via gRPC stream).
@@ -2392,6 +2434,8 @@ class UserContextInterface:
                     "types": types or ["all"],
                     "mode": mode,
                 }
+                if precision_level != "high":
+                    body["precision_level"] = precision_level
                 if skip_server_st:
                     body["include_conversation_context"] = False
                 result = await self._sdk._http_transport.post(
@@ -2503,6 +2547,7 @@ class CustomerContextInterface:
         max_results: int = 10,
         types: Optional[List[str]] = None,
         mode: str = "fast",
+        precision_level: str = "high",
     ) -> ContextResponse:
         """Fetch context for a customer (B2B)."""
         self._sdk._ensure_initialized()
@@ -2511,6 +2556,11 @@ class CustomerContextInterface:
         valid_modes = ("fast", "accurate")
         if mode not in valid_modes:
             raise InvalidInputError(f"Invalid mode '{mode}'. Must be one of: {valid_modes}")
+        valid_precision = ("high", "medium")
+        if precision_level not in valid_precision:
+            raise InvalidInputError(
+                f"Invalid precision_level '{precision_level}'. Must be one of: {valid_precision}"
+            )
 
         correlation_id = generate_correlation_id(self._sdk.instance_id)
         start_time = datetime.now(timezone.utc)
@@ -2522,6 +2572,7 @@ class CustomerContextInterface:
             "max_results": max_results,
             "types": types,
             "mode": mode,
+            "precision_level": precision_level,
         }
 
         # Check anticipation cache first (bundles pre-fetched via gRPC stream).
@@ -2578,6 +2629,8 @@ class CustomerContextInterface:
                     "types": types or ["all"],
                     "mode": mode,
                 }
+                if precision_level != "high":
+                    body["precision_level"] = precision_level
                 if skip_server_st:
                     body["include_conversation_context"] = False
                 result = await self._sdk._http_transport.post(
@@ -2688,6 +2741,7 @@ class ClientContextInterface:
         max_results: int = 10,
         types: Optional[List[str]] = None,
         mode: str = "fast",
+        precision_level: str = "high",
     ) -> ContextResponse:
         """Fetch organizational context."""
         self._sdk._ensure_initialized()
@@ -2696,6 +2750,11 @@ class ClientContextInterface:
         valid_modes = ("fast", "accurate")
         if mode not in valid_modes:
             raise InvalidInputError(f"Invalid mode '{mode}'. Must be one of: {valid_modes}")
+        valid_precision = ("high", "medium")
+        if precision_level not in valid_precision:
+            raise InvalidInputError(
+                f"Invalid precision_level '{precision_level}'. Must be one of: {valid_precision}"
+            )
 
         correlation_id = generate_correlation_id(self._sdk.instance_id)
         start_time = datetime.now(timezone.utc)
@@ -2707,6 +2766,7 @@ class ClientContextInterface:
             "max_results": max_results,
             "types": types,
             "mode": mode,
+            "precision_level": precision_level,
         }
 
         # Check anticipation cache first (bundles pre-fetched via gRPC stream).
@@ -2762,6 +2822,8 @@ class ClientContextInterface:
                     "types": types or ["all"],
                     "mode": mode,
                 }
+                if precision_level != "high":
+                    body["precision_level"] = precision_level
                 if skip_server_st:
                     body["include_conversation_context"] = False
                 result = await self._sdk._http_transport.post(

--- a/tests/sdk/test_precision_level_param.py
+++ b/tests/sdk/test_precision_level_param.py
@@ -1,0 +1,92 @@
+"""Tests for the precision_level fetch parameter (SDK side).
+
+precision_level ("high" default | "medium") is validated client-side like
+mode, included in the SDK's local cache params, and emitted in the HTTP body
+only when non-default so existing server contracts are untouched.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from maximem_synap.models.errors import InvalidInputError
+from maximem_synap.sdk import (
+    ClientContextInterface,
+    ConversationContextInterface,
+    CustomerContextInterface,
+    UserContextInterface,
+)
+
+
+def _fake_sdk():
+    # MagicMock base: incidental attrs (turn counters, telemetry, summary
+    # gates) auto-mock; everything awaited or branch-relevant is explicit.
+    sdk = MagicMock()
+    sdk._ensure_initialized = lambda: None
+    sdk.instance_id = "inst_test"
+    sdk._client_id = ""
+    sdk._anticipation_cache.lookup.return_value = None
+    sdk._cache_manager.get.return_value = None
+    sdk._get_auth_context = AsyncMock(return_value=MagicMock())
+    sdk._http_transport.post = AsyncMock(
+        return_value={"context": {"facts": []}, "ttl_seconds": 300}
+    )
+    sdk.instance.is_listening = False
+    sdk._is_st_authoritative = lambda: False
+    sdk._should_inject_user_summary = MagicMock(return_value=False)
+    sdk._maybe_trigger_compaction = AsyncMock()
+    return sdk
+
+
+_INTERFACES = [
+    (UserContextInterface, {"user_id": "u1", "customer_id": "c1"}),
+    (CustomerContextInterface, {"customer_id": "c1"}),
+    (ClientContextInterface, {}),
+    (ConversationContextInterface, {"conversation_id": "conv1"}),
+]
+
+
+class TestValidation:
+    @pytest.mark.parametrize("iface_cls,kwargs", _INTERFACES)
+    @pytest.mark.asyncio
+    async def test_invalid_precision_level_raises(self, iface_cls, kwargs):
+        iface = iface_cls(_fake_sdk())
+        with pytest.raises(InvalidInputError):
+            await iface.fetch(**kwargs, precision_level="low")
+
+    @pytest.mark.parametrize("iface_cls,kwargs", _INTERFACES)
+    @pytest.mark.asyncio
+    async def test_invalid_mode_still_raises(self, iface_cls, kwargs):
+        iface = iface_cls(_fake_sdk())
+        with pytest.raises(InvalidInputError):
+            await iface.fetch(**kwargs, mode="turbo")
+
+
+class TestBodyEmission:
+    @pytest.mark.asyncio
+    async def test_medium_included_in_body(self):
+        sdk = _fake_sdk()
+        iface = UserContextInterface(sdk)
+        await iface.fetch(user_id="u1", customer_id="c1", precision_level="medium")
+        _, call_kwargs = sdk._http_transport.post.call_args
+        assert call_kwargs["json"]["precision_level"] == "medium"
+
+    @pytest.mark.asyncio
+    async def test_high_default_omitted_from_body(self):
+        """Default "high" is NOT sent — the wire contract stays identical to
+        pre-feature SDKs, so old servers never see an unknown field."""
+        sdk = _fake_sdk()
+        iface = UserContextInterface(sdk)
+        await iface.fetch(user_id="u1", customer_id="c1")
+        _, call_kwargs = sdk._http_transport.post.call_args
+        assert "precision_level" not in call_kwargs["json"]
+
+    @pytest.mark.asyncio
+    async def test_precision_level_keys_local_cache(self):
+        """medium and high fetches must not share a local cache entry."""
+        sdk = _fake_sdk()
+        iface = UserContextInterface(sdk)
+        await iface.fetch(user_id="u1", customer_id="c1", precision_level="medium")
+        _, get_kwargs = sdk._cache_manager.get.call_args
+        assert get_kwargs["query"]["precision_level"] == "medium"


### PR DESCRIPTION
SDK companion to maximem-ai/maximem_synap#878 (merged): optional `precision_level` kwarg on all five context fetch surfaces — `"high"` (default) keeps the server-side relevance-refinement pass; `"medium"` skips it for faster, less precisely filtered results (recall isn't impacted).

- Validation mirrors `mode` (InvalidInputError on bad values) on all four scoped interfaces + unified fetch delegation.
- SDK local cache params include it — medium/high never share a cache entry.
- **Body emission only when non-default** — wire contract to older servers unchanged.
- Tool schema enum + `_invoke_scope_fetch`, facade controllers, JS SDK (`precisionLevel`).
- Version 0.2.6 → 0.3.0 (additive, minor). PyPI publish follows merge (separate step).

Tests: 11 new in `tests/sdk/test_precision_level_param.py`, all green. Pre-existing failures on main are untouched and documented in the commit message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)