### PR TITLE
sync: Vercel eve + Strands/CAMEL/Smolagents integrations + MCP handshake fix + SDK catch-up

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,7 @@ agent = ReActAgent.from_tools(tools, memory=memory)
 | Claude Agent (TypeScript) | [`@maximem/synap-claude-agent`](packages/integrations/synap-claude-agent-ts/) | `npm i @maximem/synap-claude-agent` |
 | Mastra | [`@maximem/synap-mastra`](packages/integrations/synap-mastra/) | `npm i @maximem/synap-mastra` |
 | Vercel AI SDK | [`@maximem/synap-vercel-adk`](packages/integrations/synap-vercel-adk/) | `npm i @maximem/synap-vercel-adk` |
+| Vercel eve | [`@maximem/synap-eve`](packages/integrations/synap-eve/) | `npm i @maximem/synap-eve` |
 | NVIDIA NeMo Agent Toolkit | [`maximem-synap-nemo-agent-toolkit`](packages/integrations/synap-nemo-agent-toolkit/) | `pip install maximem-synap-nemo-agent-toolkit` |
 | Microsoft Agent Framework | [`maximem-synap-microsoft-agent`](packages/integrations/synap-microsoft-agent/) | `pip install maximem-synap-microsoft-agent` |
 | Strands Agents | [`maximem-synap-strands-agents`](packages/integrations/synap-strands-agents/) | `pip install maximem-synap-strands-agents` |

--- a/README.md
+++ b/README.md
@@ -257,6 +257,9 @@ agent = ReActAgent.from_tools(tools, memory=memory)
 | Vercel AI SDK | [`@maximem/synap-vercel-adk`](packages/integrations/synap-vercel-adk/) | `npm i @maximem/synap-vercel-adk` |
 | NVIDIA NeMo Agent Toolkit | [`maximem-synap-nemo-agent-toolkit`](packages/integrations/synap-nemo-agent-toolkit/) | `pip install maximem-synap-nemo-agent-toolkit` |
 | Microsoft Agent Framework | [`maximem-synap-microsoft-agent`](packages/integrations/synap-microsoft-agent/) | `pip install maximem-synap-microsoft-agent` |
+| Strands Agents | [`maximem-synap-strands-agents`](packages/integrations/synap-strands-agents/) | `pip install maximem-synap-strands-agents` |
+| CAMEL-AI | [`maximem-synap-camel-ai`](packages/integrations/synap-camel-ai/) | `pip install maximem-synap-camel-ai` |
+| Smolagents | [`maximem-synap-smolagents`](packages/integrations/synap-smolagents/) | `pip install maximem-synap-smolagents` |
 
 <!-- END integrations -->
 

--- a/packages/integrations/synap-camel-ai/README.md
+++ b/packages/integrations/synap-camel-ai/README.md
@@ -1,0 +1,85 @@
+# maximem-synap-camel-ai
+
+Synap memory integration for [CAMEL-AI](https://github.com/camel-ai/camel) — plug
+Synap in as a native `AgentMemory` so your `ChatAgent` gains persistent long-term
+memory, plus explicit tools and short-term context.
+
+```bash
+pip install maximem-synap-camel-ai camel-ai
+```
+
+## Surfaces
+
+| Surface | CAMEL extension point | Purpose |
+|---------|-----------------------|---------|
+| `SynapAgentMemory` | `AgentMemory` → `ChatAgent(memory=...)` | Recall + persistence layered over CAMEL's own conversation history |
+| `create_synap_tools` | `FunctionTool` | Explicit `search_memory` / `store_memory` the model can call |
+| `synap_st_system_message` | `ChatAgent(system_message=...)` | Fold Synap short-term context into the system prompt |
+
+## Native memory
+
+`SynapAgentMemory` subclasses CAMEL's `ChatHistoryMemory` and **augments** it rather
+than replacing it — CAMEL's `get_context()` is the sole source of the model's input,
+so the memory must return the real conversation (system + user + assistant). On top
+of that live history it:
+
+- **recalls** Synap's long-term memories and prepends them as a system context block
+  (using the latest user turn as the query);
+- **persists** each completed turn's accumulated transcript to Synap for server-side
+  extraction, under a stable document id.
+
+```python
+from camel.agents import ChatAgent
+from camel.models import ModelFactory
+from maximem_synap import MaximemSynapSDK
+from synap_camel_ai import SynapAgentMemory
+
+sdk = MaximemSynapSDK(api_key="sk-...")
+memory = SynapAgentMemory(sdk, user_id="alice", customer_id="acme")
+
+agent = ChatAgent(
+    system_message="You are a concise, friendly support agent.",
+    model=ModelFactory.create(model_platform="openai", model_type="gpt-4o"),
+    memory=memory,            # constructor only — not agent.memory = ...
+)
+print(agent.step("Remind me what plan I'm on and my open ticket.").msgs[0].content)
+```
+
+Attach the memory via the **constructor** (`ChatAgent(memory=...)`), not
+`agent.memory = ...` afterward.
+
+## Explicit tools
+
+```python
+from synap_camel_ai import create_synap_tools
+
+agent = ChatAgent(
+    system_message="You are a helpful assistant.",
+    tools=create_synap_tools(sdk, user_id="alice", customer_id="acme"),
+)
+```
+
+## Short-term context
+
+```python
+from synap_camel_ai import SynapAgentMemory, synap_st_system_message
+
+agent = ChatAgent(
+    system_message=synap_st_system_message(
+        sdk, conversation_id="conv_abc",
+        system_message="You are a support agent.",
+    ),
+    memory=SynapAgentMemory(sdk, user_id="alice"),
+)
+```
+
+## Error policy
+
+- **Reads** (`search_memory`, memory recall) degrade — a Synap blip returns no recall
+  and the turn continues.
+- **The persistence write** inside the agent loop is best-effort by default
+  (`on_error="fallback"`) so a transient outage never discards a model response; set
+  `on_error="raise"` for strict environments.
+- **The explicit `store_memory` tool** raises `SynapIntegrationError` on failure.
+
+Requires Python 3.11+ and `camel-ai>=0.2.90`.

--- a/packages/integrations/synap-camel-ai/pyproject.toml
+++ b/packages/integrations/synap-camel-ai/pyproject.toml
@@ -1,0 +1,35 @@
+[build-system]
+requires = ["setuptools>=61.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "maximem-synap-camel-ai"
+version = "0.1.0"
+description = "Synap memory integration for CAMEL-AI — native AgentMemory backed by Synap"
+readme = "README.md"
+requires-python = ">=3.11"
+license = "Apache-2.0"
+authors = [
+    {name = "Synap Team"}
+]
+keywords = ["synap", "memory", "camel-ai", "camel", "ai", "agents"]
+
+dependencies = [
+    "maximem-synap>=0.2.0",
+    "maximem-synap-integrations-common>=0.1.0",
+    "camel-ai>=0.2.90",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.0",
+    "pytest-asyncio>=0.21",
+]
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["synap_camel_ai*"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+asyncio_mode = "auto"

--- a/packages/integrations/synap-camel-ai/synap_camel_ai/__init__.py
+++ b/packages/integrations/synap-camel-ai/synap_camel_ai/__init__.py
@@ -1,0 +1,45 @@
+"""Synap memory integration for CAMEL-AI.
+
+CAMEL exposes a first-class pluggable memory interface: ``ChatAgent(memory=...)``
+accepts any :class:`camel.memories.AgentMemory`. :class:`SynapAgentMemory` plugs
+Synap in there — but as an **augmentation** of CAMEL's own conversation history,
+not a replacement for it. CAMEL's ``AgentMemory.get_context()`` is the sole source
+of the model's input, so the memory must return the real conversation (system +
+user + assistant); :class:`SynapAgentMemory` therefore subclasses
+:class:`~camel.memories.ChatHistoryMemory` (which keeps that history) and adds two
+things on top:
+
+- **Recall**: ``retrieve()`` prepends Synap's long-term memories (fetched with the
+  latest user turn as the query) ahead of the live conversation.
+- **Persistence**: completed turns are ingested into Synap for server-side
+  extraction, so future sessions remember them.
+
+Typical wiring::
+
+    from camel.agents import ChatAgent
+    from camel.models import ModelFactory
+    from maximem_synap import MaximemSynapSDK
+    from synap_camel_ai import SynapAgentMemory
+
+    sdk = MaximemSynapSDK(api_key="sk-...")
+    memory = SynapAgentMemory(sdk, user_id="alice", customer_id="acme")
+
+    agent = ChatAgent(
+        system_message="You are a helpful assistant.",
+        model=ModelFactory.create(...),
+        memory=memory,           # constructor only — not agent.memory = ...
+    )
+    response = agent.step("What did we decide about the rollout?")
+
+Reads degrade (a Synap blip returns no recall rather than crashing the turn);
+the long-term persistence write is best-effort by default (``on_error="fallback"``)
+because it runs inside the agent loop. The explicit ``store_memory`` tool raises on
+failure. See :class:`SynapAgentMemory`, :func:`create_synap_tools`, and
+:func:`synap_st_system_message`.
+"""
+
+from synap_camel_ai.memory import SynapAgentMemory
+from synap_camel_ai.short_term import synap_st_system_message
+from synap_camel_ai.tools import create_synap_tools
+
+__all__ = ["SynapAgentMemory", "create_synap_tools", "synap_st_system_message"]

--- a/packages/integrations/synap-camel-ai/synap_camel_ai/memory.py
+++ b/packages/integrations/synap-camel-ai/synap_camel_ai/memory.py
@@ -1,0 +1,255 @@
+"""SynapAgentMemory — a CAMEL-AI ``AgentMemory`` backed by Synap.
+
+Why subclass :class:`~camel.memories.ChatHistoryMemory` rather than ``AgentMemory``
+directly? CAMEL's ``AgentMemory.get_context()`` is the *sole* source of the model's
+input — it returns whatever ``retrieve()`` yields. A memory that returned only Synap
+recall would strip the system prompt and the user's current question, so the agent
+could not answer. ``ChatHistoryMemory`` already keeps the live conversation;
+``SynapAgentMemory`` layers Synap on top:
+
+- ``retrieve()``: the real conversation, with Synap's long-term memories prepended as
+  a system context block (fetched using the latest user turn as the query).
+- ``write_records()``: after CAMEL stores a completed turn locally, the accumulated
+  transcript is ingested into Synap for server-side extraction.
+
+Error policy:
+- recall (read) degrades: a Synap failure logs at ERROR and returns the plain local
+  history — the turn still runs.
+- persistence (write) is best-effort by default (``on_error="fallback"``): it runs
+  inside the agent loop, so a transient ingestion failure must not discard the
+  model's just-produced response. Set ``on_error="raise"`` for strict environments.
+- ``clear()`` is a silent local reset — Synap has no public delete API, and CAMEL
+  calls ``clear()`` on every construction/summarization, so warning would be noise.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import List, Optional
+from uuid import uuid4
+
+from camel.memories import (
+    ChatHistoryMemory,
+    ContextRecord,
+    MemoryRecord,
+    ScoreBasedContextCreator,
+)
+from camel.messages import BaseMessage
+from camel.types import ModelType, OpenAIBackendRole
+from camel.utils import OpenAITokenCounter
+from maximem_synap import MaximemSynapSDK
+from synap_integrations_common import (
+    SynapIntegrationError,
+    run_async,
+    wrap_sdk_errors_async,
+)
+
+logger = logging.getLogger(__name__)
+
+# Metadata marker on every Synap doc this memory creates.
+_MARKER = "camel_ai_conversation"
+_OPEN = "<synap_long_term_memory>"
+_CLOSE = "</synap_long_term_memory>"
+
+_CONVERSATIONAL = (OpenAIBackendRole.USER, OpenAIBackendRole.ASSISTANT)
+_SYSTEM_ROLES = (OpenAIBackendRole.SYSTEM, OpenAIBackendRole.DEVELOPER)
+
+
+class SynapAgentMemory(ChatHistoryMemory):
+    """CAMEL ``AgentMemory`` that augments the local conversation with Synap.
+
+    Args:
+        sdk: Configured :class:`MaximemSynapSDK`.
+        user_id: Synap user scope. **Required.**
+        customer_id: Optional customer/org scope; empty means customer-less.
+        agent_id: Optional CAMEL agent id. ``ChatAgent`` overwrites this with its
+            own id after construction; it seeds the Synap document id.
+        mode: Synap fetch mode — ``"accurate"`` (default) or ``"fast"``.
+        max_results: Cap on recalled memories per turn.
+        token_limit: Context-window token budget for CAMEL's context creator.
+        token_counter: Override the token counter. Defaults to an offline
+            ``OpenAITokenCounter`` for GPT-4o-mini (no API key needed).
+        window_size: CAMEL recency window over local history (``None`` = unbounded).
+        storage: CAMEL key-value storage for local history (``None`` = in-memory).
+        on_error: ``"fallback"`` (default) makes the persistence write best-effort;
+            ``"raise"`` propagates :class:`SynapIntegrationError`.
+
+    Attach via ``ChatAgent(memory=SynapAgentMemory(...))`` — the constructor path
+    only. Do **not** assign ``agent.memory = ...`` after construction; that setter
+    re-runs retrieve/clear/write and would amplify the injected context.
+    """
+
+    def __init__(
+        self,
+        sdk: MaximemSynapSDK,
+        user_id: str,
+        *,
+        customer_id: str = "",
+        agent_id: Optional[str] = None,
+        mode: str = "accurate",
+        max_results: int = 5,
+        token_limit: int = 4096,
+        token_counter=None,
+        window_size: Optional[int] = None,
+        storage=None,
+        on_error: str = "fallback",
+    ) -> None:
+        if sdk is None:
+            raise ValueError("SynapAgentMemory requires a non-None sdk")
+        if not user_id or not str(user_id).strip():
+            raise ValueError("SynapAgentMemory requires a non-empty user_id")
+        if on_error not in ("fallback", "raise"):
+            raise ValueError(
+                f"SynapAgentMemory: on_error must be 'fallback' or 'raise', "
+                f"got {on_error!r}"
+            )
+        counter = token_counter or OpenAITokenCounter(ModelType.GPT_4O_MINI)
+        context_creator = ScoreBasedContextCreator(counter, token_limit)
+        super().__init__(
+            context_creator,
+            storage=storage,
+            window_size=window_size,
+            agent_id=agent_id,
+        )
+        self.sdk = sdk
+        self.user_id = user_id
+        self.customer_id = customer_id
+        self.mode = mode
+        self.max_results = max_results
+        self.on_error = on_error
+        self._turns: List[dict] = []
+        self._fallback_doc = f"camel-{uuid4().hex}"
+
+    # ── document id (lazy: ChatAgent sets agent_id AFTER __init__) ───────────
+
+    @property
+    def _doc_id(self) -> str:
+        aid = self.agent_id
+        return f"camel-{aid}" if aid else self._fallback_doc
+
+    # ── writes: preserve local history, then persist completed turns ─────────
+
+    def write_records(self, records: List[MemoryRecord]) -> None:
+        # Local history first — the agent's own context depends on it.
+        super().write_records(records)
+
+        for record in records:
+            if record.role_at_backend in _CONVERSATIONAL:
+                role = (
+                    "user"
+                    if record.role_at_backend == OpenAIBackendRole.USER
+                    else "assistant"
+                )
+                self._turns.append(
+                    {"role": role, "content": record.message.content or ""}
+                )
+
+        # Persist the accumulated transcript once per completed turn (triggered by
+        # the assistant message). Never per-message to a stable doc (that would
+        # clobber), and never at construction (system messages are skipped above).
+        if any(r.role_at_backend == OpenAIBackendRole.ASSISTANT for r in records):
+            self._persist()
+
+    def _persist(self) -> None:
+        transcript = self._render_transcript()
+        if not transcript:
+            return
+        try:
+            run_async(self._apersist(transcript))
+        except SynapIntegrationError:
+            # wrap_sdk_errors_async already logged at ERROR. In-loop write: swallow
+            # by default so a transient outage doesn't discard the model response.
+            if self.on_error == "raise":
+                raise
+
+    async def _apersist(self, transcript: str) -> None:
+        async with wrap_sdk_errors_async(
+            "camel_ai.write_records",
+            logger,
+            doc_id=self._doc_id,
+            user_id=self.user_id,
+        ):
+            await self.sdk.memories.create(
+                document=transcript,
+                user_id=self.user_id,
+                customer_id=self.customer_id or None,
+                document_type="ai-chat-conversation",
+                document_id=self._doc_id,
+                metadata={_MARKER: True},
+            )
+
+    def _render_transcript(self) -> str:
+        lines = []
+        for turn in self._turns:
+            content = (turn["content"] or "").strip()
+            if not content:
+                continue
+            label = "User" if turn["role"] == "user" else "Assistant"
+            lines.append(f"{label}: {content}")
+        return "\n\n".join(lines)
+
+    # ── reads: local conversation + prepended Synap recall ───────────────────
+
+    def retrieve(self) -> List[ContextRecord]:
+        local = super().retrieve()
+        query = self._last_user_text(local)
+        if not query:
+            return local
+        try:
+            block = run_async(self._arecall(query))
+        except Exception as exc:  # noqa: BLE001 — read-side graceful degrade
+            logger.error(
+                "SynapAgentMemory: recall fetch failed user_id=%s error=%s",
+                self.user_id,
+                exc,
+                exc_info=True,
+            )
+            return local
+        if not block:
+            return local
+        # role_at_backend (not the BaseMessage factory) drives the emitted role, so
+        # build the block with make_user_message and tag it SYSTEM at the backend —
+        # a clean system context block that preserves user/assistant alternation.
+        recall = ContextRecord(
+            memory_record=MemoryRecord(
+                message=BaseMessage.make_user_message(
+                    "system", f"{_OPEN}\n{block}\n{_CLOSE}"
+                ),
+                role_at_backend=OpenAIBackendRole.SYSTEM,
+            ),
+            score=1.0,
+        )
+        split = self._first_non_system_index(local)
+        return local[:split] + [recall] + local[split:]
+
+    async def _arecall(self, query: str) -> str:
+        response = await self.sdk.fetch(
+            user_id=self.user_id,
+            customer_id=self.customer_id or None,
+            search_query=[query],
+            max_results=self.max_results,
+            mode=self.mode,
+            include_conversation_context=False,
+        )
+        return (getattr(response, "formatted_context", None) or "").strip()
+
+    def _last_user_text(self, records: List[ContextRecord]) -> str:
+        for record in reversed(records):
+            mr = record.memory_record
+            if mr.role_at_backend == OpenAIBackendRole.USER:
+                text = (mr.message.content or "").strip()
+                if text and not text.startswith(_OPEN):
+                    return text
+        return ""
+
+    def _first_non_system_index(self, records: List[ContextRecord]) -> int:
+        for i, record in enumerate(records):
+            if record.memory_record.role_at_backend not in _SYSTEM_ROLES:
+                return i
+        return len(records)
+
+    # ── clear: silent local reset (Synap has no public delete API) ───────────
+
+    def clear(self) -> None:
+        super().clear()
+        self._turns.clear()

--- a/packages/integrations/synap-camel-ai/synap_camel_ai/short_term.py
+++ b/packages/integrations/synap-camel-ai/synap_camel_ai/short_term.py
@@ -1,0 +1,152 @@
+"""Synap short-term context for CAMEL-AI.
+
+CAMEL's ``ChatAgent(system_message=...)`` takes a static string, so short-term
+context is folded into the system message once, at construction, via
+``sdk.conversation.context.get_context_for_prompt``. Returns the composed system
+message string.
+
+Quality contract (mirrors the other Synap integrations):
+
+- ``conversation_id`` required + explicit.
+- SDK failures never crash construction by default (``on_error="fallback"``):
+  the bare ``system_message`` is returned.
+- Empty short-term context is a no-op — the user's ``system_message`` is untouched.
+- ``on_error="raise"`` propagates :class:`SynapIntegrationError` for strict setups.
+
+Because the context is fetched once at construction, it is a snapshot; rebuild the
+agent (or re-call this) to refresh it.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Literal, Optional
+
+from maximem_synap import MaximemSynapSDK
+from synap_integrations_common import (
+    SynapIntegrationError,
+    run_async,
+    wrap_sdk_errors_async,
+)
+
+logger = logging.getLogger(__name__)
+
+_SUPPORTED_STYLES = ("structured", "narrative", "bullet_points")
+_DEFAULT_OPEN = "<synap_short_term_context>"
+_DEFAULT_CLOSE = "</synap_short_term_context>"
+
+_OnError = Literal["fallback", "raise"]
+
+
+def _validate_args(
+    sdk: Optional[MaximemSynapSDK],
+    conversation_id: str,
+    style: str,
+    on_error: str,
+) -> None:
+    if sdk is None:
+        raise ValueError("synap_st_system_message requires a non-None sdk")
+    if not conversation_id or not str(conversation_id).strip():
+        raise ValueError(
+            "synap_st_system_message requires a non-empty conversation_id"
+        )
+    if style not in _SUPPORTED_STYLES:
+        raise ValueError(
+            f"synap_st_system_message: unsupported style={style!r}; "
+            f"expected one of {_SUPPORTED_STYLES}"
+        )
+    if on_error not in ("fallback", "raise"):
+        raise ValueError(
+            f"synap_st_system_message: on_error must be 'fallback' or 'raise', "
+            f"got {on_error!r}"
+        )
+
+
+async def _fetch_st_block(
+    sdk: MaximemSynapSDK,
+    conversation_id: str,
+    style: str,
+    on_error: _OnError,
+) -> str:
+    try:
+        async with wrap_sdk_errors_async(
+            "camel_ai.synap_st_system_message",
+            logger,
+            conversation_id=conversation_id,
+            style=style,
+        ):
+            response = await sdk.conversation.context.get_context_for_prompt(
+                conversation_id=conversation_id,
+                style=style,
+            )
+    except SynapIntegrationError:
+        if on_error == "raise":
+            raise
+        return ""
+    if not getattr(response, "available", False):
+        return ""
+    return (getattr(response, "formatted_context", None) or "").strip()
+
+
+def _compose(
+    st_block: str,
+    system_message: str,
+    preamble_open: Optional[str],
+    preamble_close: Optional[str],
+) -> str:
+    parts = []
+    st_block = (st_block or "").strip()
+    system_message = (system_message or "").strip()
+    if st_block:
+        if preamble_open and preamble_close:
+            parts.append(f"{preamble_open}\n{st_block}\n{preamble_close}")
+        else:
+            parts.append(st_block)
+    if system_message:
+        parts.append(system_message)
+    return "\n\n".join(parts)
+
+
+def synap_st_system_message(
+    sdk: MaximemSynapSDK,
+    conversation_id: str,
+    *,
+    system_message: str = "",
+    style: str = "narrative",
+    preamble_open: Optional[str] = _DEFAULT_OPEN,
+    preamble_close: Optional[str] = _DEFAULT_CLOSE,
+    on_error: _OnError = "fallback",
+) -> str:
+    """Compose a CAMEL system message with Synap short-term context prepended.
+
+    Args:
+        sdk: Initialised :class:`MaximemSynapSDK`.
+        conversation_id: Synap conversation id. **Required.**
+        system_message: Your own static system message; ST is prepended above it.
+        style: One of ``"structured" | "narrative" | "bullet_points"``.
+        preamble_open / preamble_close: ST block wrappers; pass ``None`` for both
+            to drop the tags.
+        on_error: ``"fallback"`` (default) returns the bare ``system_message`` on
+            SDK failure; ``"raise"`` propagates :class:`SynapIntegrationError`.
+
+    Returns:
+        The composed system message string for ``ChatAgent(system_message=...)``.
+
+    Example::
+
+        from camel.agents import ChatAgent
+        from synap_camel_ai import SynapAgentMemory, synap_st_system_message
+
+        agent = ChatAgent(
+            system_message=synap_st_system_message(
+                sdk, conversation_id="conv_abc",
+                system_message="You are a helpful support agent.",
+            ),
+            memory=SynapAgentMemory(sdk, user_id="alice"),
+        )
+    """
+    _validate_args(sdk, conversation_id, style, on_error)
+    st_block = run_async(
+        _fetch_st_block(sdk, conversation_id, style, on_error)
+    )
+    return _compose(st_block, system_message, preamble_open, preamble_close)

--- a/packages/integrations/synap-camel-ai/synap_camel_ai/tools.py
+++ b/packages/integrations/synap-camel-ai/synap_camel_ai/tools.py
@@ -1,0 +1,98 @@
+"""Explicit Synap memory tools for CAMEL-AI agents.
+
+For agents that want model-driven memory (the model decides when to search or
+store) instead of, or alongside, the always-on :class:`SynapAgentMemory`. Returns
+two :class:`camel.toolkits.FunctionTool` objects to pass to ``ChatAgent(tools=...)``.
+
+CAMEL tool bodies are synchronous, so each drives the async SDK through
+``run_async``. Reads degrade (return a not-found message); the write raises
+``SynapIntegrationError`` so a failed store is observable to the caller.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import List
+
+from camel.toolkits import FunctionTool
+from maximem_synap import MaximemSynapSDK
+from synap_integrations_common import run_async, wrap_sdk_errors
+
+logger = logging.getLogger(__name__)
+
+
+def create_synap_tools(
+    sdk: MaximemSynapSDK,
+    user_id: str,
+    *,
+    customer_id: str = "",
+) -> List[FunctionTool]:
+    """Build ``search_memory`` and ``store_memory`` tools bound to a Synap scope.
+
+    Args:
+        sdk: Configured :class:`MaximemSynapSDK`.
+        user_id: Synap user scope. **Required.**
+        customer_id: Optional customer/org scope; empty means customer-less.
+
+    Returns:
+        A list ``[search_memory, store_memory]`` of :class:`FunctionTool`.
+    """
+    if sdk is None:
+        raise ValueError("create_synap_tools requires a non-None sdk")
+    if not user_id or not str(user_id).strip():
+        raise ValueError("create_synap_tools requires a non-empty user_id")
+
+    def search_memory(query: str) -> str:
+        """Search the user's long-term memory for relevant context.
+
+        Args:
+            query (str): What to look up in memory.
+
+        Returns:
+            str: Formatted memory context, or a not-found message.
+        """
+        try:
+            response = run_async(
+                sdk.fetch(
+                    user_id=user_id,
+                    customer_id=customer_id or None,
+                    search_query=[query],
+                    include_conversation_context=False,
+                )
+            )
+        except Exception as exc:  # noqa: BLE001 — read-side graceful degrade
+            logger.error(
+                "create_synap_tools.search_memory failed user_id=%s error=%s",
+                user_id,
+                exc,
+                exc_info=True,
+            )
+            return "No relevant memories found."
+        return (
+            getattr(response, "formatted_context", None)
+            or "No relevant memories found."
+        )
+
+    def store_memory(content: str) -> str:
+        """Store a fact or note in the user's long-term memory for future recall.
+
+        Args:
+            content (str): The information to remember.
+
+        Returns:
+            str: Confirmation including the Synap ingestion id.
+        """
+        with wrap_sdk_errors("camel_ai.store_memory", logger, user_id=user_id):
+            result = run_async(
+                sdk.memories.create(
+                    document=content,
+                    user_id=user_id,
+                    customer_id=customer_id or None,
+                )
+            )
+        return (
+            f"Memory stored (ingestion_id: "
+            f"{getattr(result, 'ingestion_id', 'unknown')})"
+        )
+
+    return [FunctionTool(search_memory), FunctionTool(store_memory)]

--- a/packages/integrations/synap-camel-ai/tests/conftest.py
+++ b/packages/integrations/synap-camel-ai/tests/conftest.py
@@ -1,0 +1,30 @@
+"""Pytest conftest for synap-camel-ai tests.
+
+Re-exports shared fixtures from the canonical harness so tests can request
+``mock_sdk`` and ``failing_sdk`` without local duplication — same pattern as
+synap-agno.
+"""
+
+import os
+import sys
+
+sys.path.insert(
+    0,
+    os.path.join(os.path.dirname(__file__), "../../../synap/sdk/python"),
+)
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(
+    0,
+    os.path.join(os.path.dirname(__file__), "../../synap-integrations-common"),
+)
+
+from synap_integrations_common.testing import (  # noqa: F401, E402
+    mock_sdk,
+    failing_sdk,
+    make_fact,
+    make_preference,
+    make_episode,
+    make_emotion,
+    make_temporal_event,
+    make_unified_response,
+)

--- a/packages/integrations/synap-camel-ai/tests/test_memory.py
+++ b/packages/integrations/synap-camel-ai/tests/test_memory.py
@@ -1,0 +1,227 @@
+"""Tests for SynapAgentMemory — the CAMEL-AI native memory backend.
+
+Covers the architect-reviewed contract: construction does no SDK I/O, completed
+turns persist the accumulated transcript to a stable doc id, retrieve augments the
+real local conversation with prepended Synap recall, reads degrade, and the in-loop
+persistence write is best-effort (log-not-raise) by default.
+"""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from camel.memories import AgentMemory, MemoryRecord
+from camel.messages import BaseMessage
+from camel.types import OpenAIBackendRole
+
+from synap_camel_ai import SynapAgentMemory
+from synap_integrations_common import SynapIntegrationError
+
+_MEM_TAG = "<synap_long_term_memory>"
+
+
+# ── record factories ─────────────────────────────────────────────────────────
+
+
+def user_rec(text):
+    return MemoryRecord(
+        message=BaseMessage.make_user_message("user", text),
+        role_at_backend=OpenAIBackendRole.USER,
+    )
+
+
+def asst_rec(text):
+    return MemoryRecord(
+        message=BaseMessage.make_assistant_message("assistant", text),
+        role_at_backend=OpenAIBackendRole.ASSISTANT,
+    )
+
+
+def sys_rec(text):
+    return MemoryRecord(
+        message=BaseMessage.make_system_message("system", text),
+        role_at_backend=OpenAIBackendRole.SYSTEM,
+    )
+
+
+def contents(records):
+    return [r.memory_record.message.content for r in records]
+
+
+def roles(records):
+    return [r.memory_record.role_at_backend for r in records]
+
+
+# ── construction / validation ────────────────────────────────────────────────
+
+
+def test_is_agent_memory(mock_sdk):
+    assert isinstance(SynapAgentMemory(mock_sdk, "alice"), AgentMemory)
+
+
+def test_construction_does_no_sdk_io(failing_sdk):
+    SynapAgentMemory(failing_sdk, "alice", customer_id="acme")
+    failing_sdk.memories.create.assert_not_called()
+    failing_sdk.fetch.assert_not_called()
+
+
+def test_requires_sdk():
+    with pytest.raises(ValueError):
+        SynapAgentMemory(None, "alice")
+
+
+def test_requires_user_id(mock_sdk):
+    with pytest.raises(ValueError):
+        SynapAgentMemory(mock_sdk, "")
+
+
+def test_rejects_bad_on_error(mock_sdk):
+    with pytest.raises(ValueError):
+        SynapAgentMemory(mock_sdk, "alice", on_error="explode")
+
+
+# ── writes: persistence semantics ────────────────────────────────────────────
+
+
+def test_user_only_write_does_not_persist(mock_sdk):
+    mem = SynapAgentMemory(mock_sdk, "alice")
+    mem.write_records([user_rec("What's the plan?")])
+    mock_sdk.memories.create.assert_not_called()
+
+
+def test_system_write_is_not_persisted_or_tracked(mock_sdk):
+    mem = SynapAgentMemory(mock_sdk, "alice")
+    mem.write_records([sys_rec("You are helpful")])
+    mock_sdk.memories.create.assert_not_called()
+    assert mem._turns == []
+
+
+def test_completed_turn_persists_accumulated_transcript(mock_sdk):
+    mem = SynapAgentMemory(mock_sdk, "alice", customer_id="acme")
+    mem.write_records([user_rec("What's the plan?")])
+    mock_sdk.memories.create.assert_not_called()
+    mem.write_records([asst_rec("The plan is X")])
+    mock_sdk.memories.create.assert_called_once()
+    kwargs = mock_sdk.memories.create.call_args.kwargs
+    assert kwargs["document_type"] == "ai-chat-conversation"
+    assert kwargs["user_id"] == "alice"
+    assert kwargs["customer_id"] == "acme"
+    assert "User: What's the plan?" in kwargs["document"]
+    assert "Assistant: The plan is X" in kwargs["document"]
+
+
+def test_stable_doc_id_and_growing_transcript_across_turns(mock_sdk):
+    mem = SynapAgentMemory(mock_sdk, "alice")
+    mem.write_records([user_rec("q1")])
+    mem.write_records([asst_rec("a1")])
+    first_doc = mock_sdk.memories.create.call_args.kwargs["document_id"]
+    mem.write_records([user_rec("q2")])
+    mem.write_records([asst_rec("a2")])
+    second = mock_sdk.memories.create.call_args.kwargs
+    assert second["document_id"] == first_doc
+    assert all(x in second["document"] for x in ("q1", "a1", "q2", "a2"))
+    assert mock_sdk.memories.create.call_count == 2
+
+
+def test_doc_id_tracks_agent_id(mock_sdk):
+    mem = SynapAgentMemory(mock_sdk, "alice")
+    fallback = mem._doc_id
+    mem.agent_id = "agent-42"
+    assert mem._doc_id == "camel-agent-42"
+    assert mem._doc_id != fallback
+
+
+def test_persist_failure_is_swallowed_by_default(failing_sdk):
+    mem = SynapAgentMemory(failing_sdk, "alice")
+    mem.write_records([user_rec("hi")])
+    mem.write_records([asst_rec("hello")])  # persist raises internally → swallowed
+
+
+def test_persist_failure_raises_when_strict(failing_sdk):
+    mem = SynapAgentMemory(failing_sdk, "alice", on_error="raise")
+    mem.write_records([user_rec("hi")])
+    with pytest.raises(SynapIntegrationError):
+        mem.write_records([asst_rec("hello")])
+
+
+# ── reads: recall augmentation ───────────────────────────────────────────────
+
+
+def test_retrieve_prepends_recall_after_system(mock_sdk):
+    mem = SynapAgentMemory(mock_sdk, "alice")
+    mem.write_records([sys_rec("You are helpful")])
+    mem.write_records([user_rec("What's my plan?")])
+    recs = mem.retrieve()
+    assert len(recs) == 3
+    assert roles(recs)[0] == OpenAIBackendRole.SYSTEM  # original system first
+    assert _MEM_TAG in contents(recs)[1]  # recall injected second
+    assert roles(recs)[1] == OpenAIBackendRole.SYSTEM  # as a system block
+    assert roles(recs)[2] == OpenAIBackendRole.USER  # conversation preserved
+    assert "What's my plan?" in contents(recs)[2]
+    mock_sdk.fetch.assert_called_once()
+    assert mock_sdk.fetch.call_args.kwargs["search_query"] == ["What's my plan?"]
+
+
+def test_retrieve_no_user_message_skips_fetch(mock_sdk):
+    mem = SynapAgentMemory(mock_sdk, "alice")
+    mem.write_records([sys_rec("You are helpful")])
+    recs = mem.retrieve()
+    mock_sdk.fetch.assert_not_called()
+    assert not any(_MEM_TAG in (c or "") for c in contents(recs))
+
+
+def test_retrieve_degrades_to_local_on_fetch_failure(failing_sdk):
+    mem = SynapAgentMemory(failing_sdk, "alice")
+    mem.write_records([user_rec("hi there")])  # user-only: no persist, no raise
+    recs = mem.retrieve()  # fetch raises → degrade
+    assert [r.memory_record.message.content for r in recs] == ["hi there"]
+    assert not any(_MEM_TAG in (c or "") for c in contents(recs))
+
+
+def test_retrieve_no_recall_when_context_empty(mock_sdk):
+    resp = MagicMock()
+    resp.formatted_context = ""
+    mock_sdk.fetch = AsyncMock(return_value=resp)
+    mem = SynapAgentMemory(mock_sdk, "alice")
+    mem.write_records([user_rec("anything")])
+    recs = mem.retrieve()
+    assert not any(_MEM_TAG in (c or "") for c in contents(recs))
+
+
+def test_retrieve_uses_last_user_message_as_query(mock_sdk):
+    mem = SynapAgentMemory(mock_sdk, "alice")
+    mem.write_records([user_rec("first question")])
+    mem.write_records([asst_rec("an answer")])
+    mem.write_records([user_rec("second question")])
+    mem.retrieve()
+    assert mock_sdk.fetch.call_args.kwargs["search_query"] == ["second question"]
+
+
+def test_max_results_flows_to_fetch(mock_sdk):
+    mem = SynapAgentMemory(mock_sdk, "alice", max_results=17)
+    mem.write_records([user_rec("q")])
+    mem.retrieve()
+    assert mock_sdk.fetch.call_args.kwargs["max_results"] == 17
+
+
+# ── clear ────────────────────────────────────────────────────────────────────
+
+
+def test_clear_is_silent_and_resets_turns(mock_sdk):
+    mem = SynapAgentMemory(mock_sdk, "alice")
+    mem.write_records([user_rec("hi")])
+    mem.clear()
+    assert mem._turns == []
+    assert mem.retrieve() == []
+
+
+# ── structural: real ChatAgent accepts it ────────────────────────────────────
+
+
+def test_chatagent_accepts_memory(mock_sdk, monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")  # construction validates presence only
+    from camel.agents import ChatAgent
+
+    mem = SynapAgentMemory(mock_sdk, "alice")
+    agent = ChatAgent(system_message="You are helpful", memory=mem)
+    assert agent.memory is mem
+    mock_sdk.memories.create.assert_not_called()  # no I/O during construction

--- a/packages/integrations/synap-camel-ai/tests/test_short_term.py
+++ b/packages/integrations/synap-camel-ai/tests/test_short_term.py
@@ -1,0 +1,95 @@
+"""Tests for synap_st_system_message — short-term context for CAMEL system prompts."""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from synap_camel_ai import synap_st_system_message
+from synap_integrations_common import SynapIntegrationError
+
+
+def _unavailable(mock_sdk):
+    resp = MagicMock()
+    resp.available = False
+    resp.formatted_context = ""
+    mock_sdk.conversation.context.get_context_for_prompt = AsyncMock(return_value=resp)
+    return mock_sdk
+
+
+# ── validation ───────────────────────────────────────────────────────────────
+
+
+def test_requires_sdk():
+    with pytest.raises(ValueError):
+        synap_st_system_message(None, "conv")
+
+
+def test_requires_conversation_id(mock_sdk):
+    with pytest.raises(ValueError):
+        synap_st_system_message(mock_sdk, "")
+
+
+def test_rejects_bad_style(mock_sdk):
+    with pytest.raises(ValueError):
+        synap_st_system_message(mock_sdk, "conv", style="haiku")
+
+
+def test_rejects_bad_on_error(mock_sdk):
+    with pytest.raises(ValueError):
+        synap_st_system_message(mock_sdk, "conv", on_error="explode")
+
+
+# ── composition ──────────────────────────────────────────────────────────────
+
+
+def test_prepends_context_above_system_message(mock_sdk):
+    out = synap_st_system_message(
+        mock_sdk, "conv", system_message="You are a support agent."
+    )
+    assert "Recent conversation summary" in out
+    assert "You are a support agent." in out
+    assert out.index("Recent conversation summary") < out.index("You are a support agent.")
+    assert "<synap_short_term_context>" in out
+
+
+def test_tags_dropped_when_preamble_none(mock_sdk):
+    out = synap_st_system_message(
+        mock_sdk, "conv", system_message="BASE",
+        preamble_open=None, preamble_close=None,
+    )
+    assert "<synap_short_term_context>" not in out
+    assert "Recent conversation summary" in out
+    assert "BASE" in out
+
+
+def test_style_flows_to_sdk(mock_sdk):
+    synap_st_system_message(mock_sdk, "conv", style="bullet_points")
+    assert (
+        mock_sdk.conversation.context.get_context_for_prompt.call_args.kwargs["style"]
+        == "bullet_points"
+    )
+
+
+# ── empty / unavailable ──────────────────────────────────────────────────────
+
+
+def test_unavailable_context_returns_bare_system_message(mock_sdk):
+    sdk = _unavailable(mock_sdk)
+    assert synap_st_system_message(sdk, "conv", system_message="BASE") == "BASE"
+
+
+def test_unavailable_with_no_system_message_returns_empty(mock_sdk):
+    sdk = _unavailable(mock_sdk)
+    assert synap_st_system_message(sdk, "conv") == ""
+
+
+# ── error handling ───────────────────────────────────────────────────────────
+
+
+def test_fallback_swallows_sdk_failure(failing_sdk):
+    out = synap_st_system_message(failing_sdk, "conv", system_message="BASE")
+    assert out == "BASE"
+
+
+def test_raise_propagates_sdk_failure(failing_sdk):
+    with pytest.raises(SynapIntegrationError):
+        synap_st_system_message(failing_sdk, "conv", system_message="BASE", on_error="raise")

--- a/packages/integrations/synap-camel-ai/tests/test_tools.py
+++ b/packages/integrations/synap-camel-ai/tests/test_tools.py
@@ -1,0 +1,62 @@
+"""Tests for create_synap_tools — CAMEL FunctionTools for explicit memory access."""
+
+import pytest
+
+from camel.toolkits import FunctionTool
+
+from synap_camel_ai import create_synap_tools
+from synap_integrations_common import SynapIntegrationError
+
+
+def _by_name(tools):
+    return {t.get_openai_tool_schema()["function"]["name"]: t for t in tools}
+
+
+def test_returns_two_function_tools(mock_sdk):
+    tools = create_synap_tools(mock_sdk, "alice")
+    assert len(tools) == 2
+    assert all(isinstance(t, FunctionTool) for t in tools)
+    assert set(_by_name(tools)) == {"search_memory", "store_memory"}
+
+
+def test_requires_sdk():
+    with pytest.raises(ValueError):
+        create_synap_tools(None, "alice")
+
+
+def test_requires_user_id(mock_sdk):
+    with pytest.raises(ValueError):
+        create_synap_tools(mock_sdk, "")
+
+
+def test_search_memory_returns_context(mock_sdk):
+    search = _by_name(create_synap_tools(mock_sdk, "alice"))["search_memory"]
+    out = search.func("what plan am I on")
+    assert "User Context" in out
+    assert mock_sdk.fetch.call_args.kwargs["search_query"] == ["what plan am I on"]
+
+
+def test_search_memory_degrades_on_failure(failing_sdk):
+    search = _by_name(create_synap_tools(failing_sdk, "alice"))["search_memory"]
+    assert search.func("q") == "No relevant memories found."
+
+
+def test_store_memory_returns_ingestion_id(mock_sdk):
+    store = _by_name(create_synap_tools(mock_sdk, "alice"))["store_memory"]
+    out = store.func("remember I like tea")
+    assert "ing-001" in out
+    assert mock_sdk.memories.create.call_args.kwargs["document"] == "remember I like tea"
+
+
+def test_store_memory_raises_on_failure(failing_sdk):
+    store = _by_name(create_synap_tools(failing_sdk, "alice"))["store_memory"]
+    with pytest.raises(SynapIntegrationError):
+        store.func("boom")
+
+
+def test_customer_id_flows_through(mock_sdk):
+    tools = _by_name(create_synap_tools(mock_sdk, "alice", customer_id="acme"))
+    tools["search_memory"].func("q")
+    tools["store_memory"].func("c")
+    assert mock_sdk.fetch.call_args.kwargs["customer_id"] == "acme"
+    assert mock_sdk.memories.create.call_args.kwargs["customer_id"] == "acme"

--- a/packages/integrations/synap-eve/.gitignore
+++ b/packages/integrations/synap-eve/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+*.tgz

--- a/packages/integrations/synap-eve/README.md
+++ b/packages/integrations/synap-eve/README.md
@@ -1,0 +1,73 @@
+# @maximem/synap-eve
+
+Synap memory integration for [Vercel eve](https://vercel.com/eve) agents.
+
+eve's built-in durability (Vercel Workflows) persists a single session's turn state so it survives
+crashes and redeploys — but that is short-term session state, not cross-session memory. This package
+adds **Synap** as the durable, cross-session memory layer, through two native eve extension points.
+
+> Requires `eve >= 0.25.0` and `zod >= 3.23`. Tested against `eve@0.25.1` (AI SDK v7).
+
+## Install
+
+```bash
+npm install @maximem/synap-eve
+# peers: eve, zod
+```
+
+## Surfaces
+
+### 1. Memory tools — `agent/tools/`
+
+The filename is the model-facing tool name. Point the factories at a configured Synap SDK:
+
+```ts
+// agent/tools/synap_search.ts
+import { createSynapSearchTool } from "@maximem/synap-eve";
+import { sdk } from "../lib/synap.js";
+export default createSynapSearchTool({ sdk });
+```
+
+```ts
+// agent/tools/synap_store.ts
+import { createSynapStoreTool } from "@maximem/synap-eve";
+import { sdk } from "../lib/synap.js";
+export default createSynapStoreTool({ sdk });
+```
+
+`synap_search` lets the model pull long-term context on demand; `synap_store` persists an explicit
+fact or preference for future sessions.
+
+### 2. Short-term context — `agent/instructions/`
+
+A per-turn resolver that injects Synap's compacted short-term summary into the system prompt. It
+**augments** `instructions.md`; it never replaces it.
+
+```ts
+// agent/instructions/synap.ts
+import { createSynapInstructions } from "@maximem/synap-eve";
+import { sdk } from "../lib/synap.js";
+export default createSynapInstructions({ sdk });
+```
+
+## Identity
+
+Both surfaces auto-scope from the eve session — `user_id` from `ctx.session.auth.current.principalId`
+and `conversation_id` from `ctx.session.id`. On an unauthenticated channel (`auth.current` is `null`),
+pass an explicit `userId`:
+
+```ts
+export default createSynapStoreTool({ sdk, userId: "alice", customerId: "acme" });
+```
+
+## Error policy
+
+| Operation | Behavior |
+|---|---|
+| Reads (`synap_search`, instructions recall) | Degrade — log at ERROR, return empty / `null` so the turn proceeds |
+| Writes (`synap_store`) | Raise `SynapIntegrationError` — ingestion outages are surfaced to the agent |
+| Deletes | Not supported (Synap has no public delete API) |
+
+## License
+
+Apache-2.0

--- a/packages/integrations/synap-eve/package-lock.json
+++ b/packages/integrations/synap-eve/package-lock.json
@@ -1,0 +1,2408 @@
+{
+  "name": "@maximem/synap-eve",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@maximem/synap-eve",
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "eve": "^0.25.1",
+        "typescript": "^5.7.0",
+        "vitest": "^2.1.9",
+        "zod": "^4.4.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "eve": ">=0.25.0",
+        "zod": ">=4.0.0"
+      }
+    },
+    "node_modules/@ai-sdk/gateway": {
+      "version": "4.0.23",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-4.0.23.tgz",
+      "integrity": "sha512-f85diFdPMXYJpxCjOYZchMQkRH8h3r6lhK4Q2xmzJ7UA2OQ80L3W7tFu61742xGQK7zHWm5AhxYhNuc50H9SGQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@ai-sdk/provider": "4.0.3",
+        "@ai-sdk/provider-utils": "5.0.11",
+        "@vercel/oidc": "3.2.0"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/provider": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-4.0.3.tgz",
+      "integrity": "sha512-e0CpNWJUY7OxAFAnCZkw+ri9QOHWwTs1tXP42782KFGCU07qt8NiXCrCVowyCB5dP2r5/Uls+g2oPd8kOJn9dw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@ai-sdk/provider-utils": {
+      "version": "5.0.11",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-5.0.11.tgz",
+      "integrity": "sha512-7/96wE+ZsKB35iS9ASyllrE4Ym/EolXEB7AkuJ5FI++fmS85BVTAs77890C+1Z2jwHfBKjBQSBmsliOsAh0iFQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@ai-sdk/provider": "4.0.3",
+        "@standard-schema/spec": "^1.1.0",
+        "@workflow/serde": "4.1.0",
+        "eventsource-parser": "^3.0.8"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.2.tgz",
+      "integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
+      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.140.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.140.0.tgz",
+      "integrity": "sha512-h5LUOzGArYemnW1NMz/DuuQhBi96J6JL2Bk8zE4kvqxB5Sg3jxmCiH4uyOWHDkiKSt5vWlG4FIwCR/DbstcNRQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.0.tgz",
+      "integrity": "sha512-9yB1l95IrJuNGDFdOYe79vdApdz6WWBCObE+rQ2LUliYUlcyFwSYIb2xb5/Ifw7dAtMy2ZqNyd8QTSOc7duAKw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.0.tgz",
+      "integrity": "sha512-pexNaW9ACLUOaBITOpU6qVu4VrsOFIjTv6bzgu0YUATo4eUJx0V605PxwZfndpPOn0ilqGqvGQ0M8UW0IE24jg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.0.tgz",
+      "integrity": "sha512-NqKYaq0355ZmNMG4QGpxtEDxsc7tGDhjhCm4PpE0cwnBW+5Il95LJyq414niEiaKLVjnVHBEjSo1wngKxJNiFw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.0.tgz",
+      "integrity": "sha512-3vPoHzh6eBTz9IbB0/qZdSr0Qeks2echn+I4cHu2joV74VriPDdldswksEDzrl1mBB+oPRi+67+3Ib59paxIPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.0.tgz",
+      "integrity": "sha512-E6NNefZ1bUVmKJq2tJkf45J4Zyczj7qm9rUT7NY+Xo2474Y13qWAwc2tvBt0BAVbmtXR1llkxXg0Ou1jbDf2SQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.0.tgz",
+      "integrity": "sha512-D+TgkdgM1vu+7/Fpf8+v0ARW+RXEP9Ccazgm8zQ4JFFd9Q7SrYQ2TakU5S5ihazQDgpKyAgZDOcIFsvoHmTZ8w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.0.tgz",
+      "integrity": "sha512-wUqdwJBbAv0APN87GecstdMUtLjjNTs0hBALpxETD73mccFxdmt/XeizXDtN5RAlBwNKmI+Tg+blect2G+8IeQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.0.tgz",
+      "integrity": "sha512-9DtF35qR9/NrfhM4oxLplCzVVjE+KKm8Pjemi0i/sdhAWkUasjmSo8WTTubNJClhSHCfyk2yeyoXDQEDPtDAAw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.0.tgz",
+      "integrity": "sha512-RzuHrBh8X8Hntd2N4VR02QGEciq/9JhcZoTpR/Cee6otRrlILGCf3cg2ygHuih+ZebUnWmMrDX6ITI85btO6rQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.0.tgz",
+      "integrity": "sha512-MK7L0018jjh1jR3mh21G2j1zAVcpscJBlPo2z19pRjv2XOYGRhaV4LyiD8HO6nCDdZln9IFgCMIV5yt4E3klGQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.0.tgz",
+      "integrity": "sha512-gyrxLQ9NfGb/9LoVnC4kb9miUghw1mghnkfYvNHSnVIXriabnfgGPUP4RLcJm87q3KgYz4FYUG8IDiWUT+CpSw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.0.tgz",
+      "integrity": "sha512-/6VFMQGRmrhP77KXDC+StIxGzcNp5JOIyYtw0CQ8gPlzhpiIRucYfoM5FaFamHd5BJYIdH86yfP46l1p3WdrFA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.2.0.tgz",
+      "integrity": "sha512-rwdbUL465kisF24WEJLvP3JrEG6E5GRuIHt5wpMwHGERtHe4Wm2CIvtf5gTBgr2tGOHKh5NdKEAFS2VkOPE91g==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.2",
+        "@emnapi/runtime": "1.11.2",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.0.tgz",
+      "integrity": "sha512-+5suHwRiKGmhwyUaNT8a5QbrBvLFh2DbO910TEmGRH1aSxwrCezodvGQnulv4uiWEIv1Kq4ypRsJ5+O+ry1DiA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.0.tgz",
+      "integrity": "sha512-WfFv6/qGufotqBSBzBYwgpCkJBk8Nj7697LL9vTz/XWc67e0r3oewu8iMRwQj3AUL45GVD7wVsPjCsAAtW66Wg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
+      "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
+      "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
+      "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
+      "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
+      "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
+      "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
+      "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
+      "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
+      "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
+      "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
+      "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
+      "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
+      "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
+      "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
+      "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
+      "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
+      "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
+      "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
+      "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
+      "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
+      "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
+      "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
+      "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@vercel/oidc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.2.0.tgz",
+      "integrity": "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@workflow/serde": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@workflow/serde/-/serde-4.1.0.tgz",
+      "integrity": "sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true
+    },
+    "node_modules/ai": {
+      "version": "7.0.31",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-7.0.31.tgz",
+      "integrity": "sha512-pJfwKXjF5kw0rKRTePwYo60EfWb8wfzJAgf3ojln/YkOsVVKttzZAJVcRPsg37Z3a06ZdKkxX+DSrMAFlPm5Mw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@ai-sdk/gateway": "4.0.23",
+        "@ai-sdk/provider": "4.0.3",
+        "@ai-sdk/provider-utils": "5.0.11"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/consola": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
+      "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.18.0 || >=16.10.0"
+      }
+    },
+    "node_modules/crossws": {
+      "version": "0.4.10",
+      "resolved": "https://registry.npmjs.org/crossws/-/crossws-0.4.10.tgz",
+      "integrity": "sha512-pz3oubH/dt12KjqsUB0IuXW4nwRDQ583iDsP4555Cpdqx0NoU7pGlWBcayyFI8f/l/idRpgjMEfwuOxSWJYlIA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "srvx": ">=0.11.5"
+      },
+      "peerDependenciesMeta": {
+        "srvx": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/db0": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/db0/-/db0-0.3.4.tgz",
+      "integrity": "sha512-RiXXi4WaNzPTHEOu8UPQKMooIbqOEyqA1t7Z6MsdxSCeb8iUC9ko3LcmsLmeUt2SM5bctfArZKkRQggKZz7JNw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@electric-sql/pglite": "*",
+        "@libsql/client": "*",
+        "better-sqlite3": "*",
+        "drizzle-orm": "*",
+        "mysql2": "*",
+        "sqlite3": "*"
+      },
+      "peerDependenciesMeta": {
+        "@electric-sql/pglite": {
+          "optional": true
+        },
+        "@libsql/client": {
+          "optional": true
+        },
+        "better-sqlite3": {
+          "optional": true
+        },
+        "drizzle-orm": {
+          "optional": true
+        },
+        "mysql2": {
+          "optional": true
+        },
+        "sqlite3": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/env-runner": {
+      "version": "0.1.16",
+      "resolved": "https://registry.npmjs.org/env-runner/-/env-runner-0.1.16.tgz",
+      "integrity": "sha512-2LRJM4P2KLX6J83QZZrMqvgCDt/D5ea7wPcI3yYiy5cG/9rX5QwdwZFx0D7ktWnjdRyZxYjttGGorb5nFqb1CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "crossws": "^0.4.8",
+        "exsolve": "^1.1.0",
+        "httpxy": "^0.5.4",
+        "srvx": "^0.11.19"
+      },
+      "bin": {
+        "env-runner": "dist/cli.mjs"
+      },
+      "peerDependencies": {
+        "@netlify/runtime": "^4.1.23",
+        "@vercel/queue": ">=0.2.0",
+        "miniflare": "^4.20260515.0",
+        "wrangler": "^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@netlify/runtime": {
+          "optional": true
+        },
+        "@vercel/queue": {
+          "optional": true
+        },
+        "miniflare": {
+          "optional": true
+        },
+        "wrangler": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/eve": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/eve/-/eve-0.25.1.tgz",
+      "integrity": "sha512-+J+W6AU+Ch3TDW5SnlVKCgwVyTwPEFShJ4u8c9h49+bqbKIHyf4KZ9ph+ZHwEe/CxEucq7g7tkzKEiE7IGNuhg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "nitro": "3.0.260610-beta"
+      },
+      "bin": {
+        "eve": "bin/eve.js"
+      },
+      "engines": {
+        "node": ">=24"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.0",
+        "ai": "^7.0.26",
+        "braintrust": "^3.0.0",
+        "just-bash": "^3.0.0",
+        "microsandbox": "^0.5.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "braintrust": {
+          "optional": true
+        },
+        "just-bash": {
+          "optional": true
+        },
+        "microsandbox": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/exsolve": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.1.0.tgz",
+      "integrity": "sha512-D+42+T12DdIlJM3uepa55qGiL3sYdLBOxIl2ifQCzCHz4c7eiolaHsi3BIqEr7JxBzxv2pYZQX9kw16ziMcEmw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/h3": {
+      "version": "2.0.1-rc.22",
+      "resolved": "https://registry.npmjs.org/h3/-/h3-2.0.1-rc.22.tgz",
+      "integrity": "sha512-Esv0DMIuPkCTSWCA0vO73vcTqwzH1wjSrAO1TXNu/K3up1sZHa9EKMapbmxCDYBeymC3fVTk4qxp7ogQWQ+KgA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "rou3": "^0.8.1",
+        "srvx": "^0.11.15"
+      },
+      "bin": {
+        "h3": "bin/h3.mjs"
+      },
+      "engines": {
+        "node": ">=20.11.1"
+      },
+      "peerDependencies": {
+        "crossws": "^0.4.1"
+      },
+      "peerDependenciesMeta": {
+        "crossws": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/hookable": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/hookable/-/hookable-6.1.1.tgz",
+      "integrity": "sha512-U9LYDy1CwhMCnprUfeAZWZGByVbhd54hwepegYTK7Pi5NvqEj63ifz5z+xukznehT7i6NIZRu89Ay1AZmRsLEQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/httpxy": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/httpxy/-/httpxy-0.5.5.tgz",
+      "integrity": "sha512-uDjmnPyp1q4Sgzf3w+J/Fc6UqcCEj0x4Wjp7OqK5dGhNeDgpyrAmnS6ey8QWrX3SWDon2DMKf9sBa5X9+CVyMA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "dev": true,
+      "license": "(AFL-2.1 OR BSD-3-Clause)",
+      "peer": true
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/nf3": {
+      "version": "0.3.22",
+      "resolved": "https://registry.npmjs.org/nf3/-/nf3-0.3.22.tgz",
+      "integrity": "sha512-NOcqlHu22X1rUakd0SrqllP8kb3LWFmSAi1svTxaKxz+yB604xlaOmUfI3oO+RkODvaocKDDy8bgthnZL8hrkw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nitro": {
+      "version": "3.0.260610-beta",
+      "resolved": "https://registry.npmjs.org/nitro/-/nitro-3.0.260610-beta.tgz",
+      "integrity": "sha512-KPb4L5yaF/Rx/xoGMpgHRJvZhbhGiqbRKOwwPLCH9jKTKTsEUHLjnJas85AeCzaswqa8Wi52eQBtRsODC4PS0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "consola": "^3.4.2",
+        "crossws": "^0.4.6",
+        "db0": "^0.3.4",
+        "env-runner": "^0.1.12",
+        "h3": "2.0.1-rc.22",
+        "hookable": "^6.1.1",
+        "nf3": "^0.3.17",
+        "ocache": "^0.1.5",
+        "ofetch": "2.0.0-alpha.3",
+        "ohash": "^2.0.11",
+        "rolldown": "^1.1.0",
+        "srvx": "^0.11.16",
+        "unenv": "2.0.0-rc.24",
+        "unstorage": "2.0.0-alpha.7"
+      },
+      "bin": {
+        "nitro": "dist/cli/index.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "@vercel/queue": "^0.3.0",
+        "dotenv": "*",
+        "giget": "*",
+        "jiti": "^2.7.0",
+        "rollup": "^4.61.1",
+        "vite": "^7 || ^8",
+        "xml2js": "^0.6.2",
+        "zephyr-agent": "^0.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@vercel/queue": {
+          "optional": true
+        },
+        "dotenv": {
+          "optional": true
+        },
+        "giget": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "rollup": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        },
+        "xml2js": {
+          "optional": true
+        },
+        "zephyr-agent": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ocache": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/ocache/-/ocache-0.1.5.tgz",
+      "integrity": "sha512-kNNnkkVQup/QDvmTz8Q84wc2ntiyoVHDxa6eHWKt5qdGAmFRBIxy83rxgCYEjW0x06UJ9E3P6VgM2yY4rOBH4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ohash": "^2.0.11"
+      }
+    },
+    "node_modules/ofetch": {
+      "version": "2.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/ofetch/-/ofetch-2.0.0-alpha.3.tgz",
+      "integrity": "sha512-zpYTCs2byOuft65vI3z43Dd6iSdFbOZZLb9/d21aCpx2rGastVU9dOCv0lu4ykc1Ur1anAYjDi3SUvR0vq50JA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ohash": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
+      "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.19",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
+      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.0.tgz",
+      "integrity": "sha512-u7tgm5l4Yw1iTqUL4EcYOAt7fFvCgQMLeidrnD4GALlC6aOznCjezYajgxeyKw27u0Q5N7fwgCzjVyPIWzwuBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.140.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.2.0",
+        "@rolldown/binding-darwin-arm64": "1.2.0",
+        "@rolldown/binding-darwin-x64": "1.2.0",
+        "@rolldown/binding-freebsd-x64": "1.2.0",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.2.0",
+        "@rolldown/binding-linux-arm64-gnu": "1.2.0",
+        "@rolldown/binding-linux-arm64-musl": "1.2.0",
+        "@rolldown/binding-linux-ppc64-gnu": "1.2.0",
+        "@rolldown/binding-linux-s390x-gnu": "1.2.0",
+        "@rolldown/binding-linux-x64-gnu": "1.2.0",
+        "@rolldown/binding-linux-x64-musl": "1.2.0",
+        "@rolldown/binding-openharmony-arm64": "1.2.0",
+        "@rolldown/binding-wasm32-wasi": "1.2.0",
+        "@rolldown/binding-win32-arm64-msvc": "1.2.0",
+        "@rolldown/binding-win32-x64-msvc": "1.2.0"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
+      "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.62.2",
+        "@rollup/rollup-android-arm64": "4.62.2",
+        "@rollup/rollup-darwin-arm64": "4.62.2",
+        "@rollup/rollup-darwin-x64": "4.62.2",
+        "@rollup/rollup-freebsd-arm64": "4.62.2",
+        "@rollup/rollup-freebsd-x64": "4.62.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.2",
+        "@rollup/rollup-linux-arm64-musl": "4.62.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.2",
+        "@rollup/rollup-linux-loong64-musl": "4.62.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-musl": "4.62.2",
+        "@rollup/rollup-openbsd-x64": "4.62.2",
+        "@rollup/rollup-openharmony-arm64": "4.62.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.2",
+        "@rollup/rollup-win32-x64-gnu": "4.62.2",
+        "@rollup/rollup-win32-x64-msvc": "4.62.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rou3": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/rou3/-/rou3-0.8.1.tgz",
+      "integrity": "sha512-ePa+XGk00/3HuCqrEnK3LxJW7I0SdNg6EFzKUJG73hMAdDcOUC/i/aSz7LSDwLrGr33kal/rqOGydzwl6U7zBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/srvx": {
+      "version": "0.11.22",
+      "resolved": "https://registry.npmjs.org/srvx/-/srvx-0.11.22.tgz",
+      "integrity": "sha512-LqZxxBDMKuMAZzFzJnDCkFOrs9MZQZr0LvHiO/SuSZVdQaXD7xQ5UWTUxheJrQPve1qk9MG2B/yttUvJxw8egQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "srvx": "bin/srvx.mjs"
+      },
+      "engines": {
+        "node": ">=20.16.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unenv": {
+      "version": "2.0.0-rc.24",
+      "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
+      "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/unstorage": {
+      "version": "2.0.0-alpha.7",
+      "resolved": "https://registry.npmjs.org/unstorage/-/unstorage-2.0.0-alpha.7.tgz",
+      "integrity": "sha512-ELPztchk2zgFJnakyodVY3vJWGW9jy//keJ32IOJVGUMyaPydwcA1FtVvWqT0TNRch9H+cMNEGllfVFfScImog==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@azure/app-configuration": "^1.11.0",
+        "@azure/cosmos": "^4.9.1",
+        "@azure/data-tables": "^13.3.2",
+        "@azure/identity": "^4.13.0",
+        "@azure/keyvault-secrets": "^4.10.0",
+        "@azure/storage-blob": "^12.31.0",
+        "@capacitor/preferences": "^6 || ^7 || ^8",
+        "@deno/kv": ">=0.13.0",
+        "@netlify/blobs": "^6.5.0 || ^7.0.0 || ^8.1.0 || ^9.0.0 || ^10.0.0",
+        "@planetscale/database": "^1.19.0",
+        "@upstash/redis": "^1.36.2",
+        "@vercel/blob": ">=0.27.3",
+        "@vercel/functions": "^2.2.12 || ^3.0.0",
+        "@vercel/kv": "^1.0.1",
+        "aws4fetch": "^1.0.20",
+        "chokidar": "^4 || ^5",
+        "db0": ">=0.3.4",
+        "idb-keyval": "^6.2.2",
+        "ioredis": "^5.9.3",
+        "lru-cache": "^11.2.6",
+        "mongodb": "^6 || ^7",
+        "ofetch": "*",
+        "uploadthing": "^7.7.4"
+      },
+      "peerDependenciesMeta": {
+        "@azure/app-configuration": {
+          "optional": true
+        },
+        "@azure/cosmos": {
+          "optional": true
+        },
+        "@azure/data-tables": {
+          "optional": true
+        },
+        "@azure/identity": {
+          "optional": true
+        },
+        "@azure/keyvault-secrets": {
+          "optional": true
+        },
+        "@azure/storage-blob": {
+          "optional": true
+        },
+        "@capacitor/preferences": {
+          "optional": true
+        },
+        "@deno/kv": {
+          "optional": true
+        },
+        "@netlify/blobs": {
+          "optional": true
+        },
+        "@planetscale/database": {
+          "optional": true
+        },
+        "@upstash/redis": {
+          "optional": true
+        },
+        "@vercel/blob": {
+          "optional": true
+        },
+        "@vercel/functions": {
+          "optional": true
+        },
+        "@vercel/kv": {
+          "optional": true
+        },
+        "aws4fetch": {
+          "optional": true
+        },
+        "chokidar": {
+          "optional": true
+        },
+        "db0": {
+          "optional": true
+        },
+        "idb-keyval": {
+          "optional": true
+        },
+        "ioredis": {
+          "optional": true
+        },
+        "lru-cache": {
+          "optional": true
+        },
+        "mongodb": {
+          "optional": true
+        },
+        "ofetch": {
+          "optional": true
+        },
+        "uploadthing": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite-node/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/packages/integrations/synap-eve/package.json
+++ b/packages/integrations/synap-eve/package.json
@@ -1,0 +1,52 @@
+{
+  "name": "@maximem/synap-eve",
+  "version": "0.1.0",
+  "description": "Synap memory integration for Vercel eve agents",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "keywords": [
+    "synap",
+    "memory",
+    "eve",
+    "vercel",
+    "agent",
+    "ai",
+    "context"
+  ],
+  "license": "Apache-2.0",
+  "peerDependencies": {
+    "eve": ">=0.25.0",
+    "zod": ">=4.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "eve": "^0.25.1",
+    "typescript": "^5.7.0",
+    "vitest": "^2.1.9",
+    "zod": "^4.4.3"
+  }
+}

--- a/packages/integrations/synap-eve/src/__tests__/helpers.ts
+++ b/packages/integrations/synap-eve/src/__tests__/helpers.ts
@@ -1,0 +1,90 @@
+// Shared mock helpers for synap-eve tests. No shared `synap-integrations-common`
+// exists for TS packages, so the mock/failing SDK and the eve-context stub live
+// here (mirrors synap-mastra's helpers, trimmed to the surface synap-eve uses).
+
+import { vi } from "vitest";
+import type {
+  SynapSdkLike,
+  SynapFetchResponseLike,
+  SynapPromptContext,
+  SynapMemoryCreateResult,
+  EveSessionLike,
+} from "../types.js";
+
+// ── Synap response factories ──────────────────────────────────────────────────
+
+export function RICH(): SynapFetchResponseLike {
+  return {
+    formatted_context:
+      "## User Context\n### Facts\n- Senior engineer at Acme\n- Timezone PT\n",
+    facts: [{ id: "f1", content: "User is a senior engineer at Acme", confidence: 0.92 }],
+    preferences: [{ id: "p1", content: "Prefers email over Slack", strength: 0.9 }],
+    episodes: [],
+    emotions: [],
+    temporal_events: [],
+  };
+}
+
+export function EMPTY(): SynapFetchResponseLike {
+  return { formatted_context: "", facts: [], preferences: [], episodes: [], emotions: [], temporal_events: [] };
+}
+
+export function promptContext(available = true): SynapPromptContext {
+  return {
+    formatted_context: available ? "User is a senior engineer. Prefers email updates." : "",
+    available,
+    recent_messages: [],
+    recent_message_count: 0,
+    total_message_count: 0,
+  };
+}
+
+// ── SDK mocks ─────────────────────────────────────────────────────────────────
+
+export interface MakeSdkOptions {
+  fetchResponse?: SynapFetchResponseLike;
+  promptCtx?: SynapPromptContext;
+  ingestionId?: string;
+}
+
+export function makeSdk(opts: MakeSdkOptions = {}): SynapSdkLike {
+  const fetchResponse = opts.fetchResponse ?? RICH();
+  const ctx = opts.promptCtx ?? promptContext();
+  const ingestionId = opts.ingestionId ?? "ing-test-001";
+  return {
+    fetch: vi.fn().mockResolvedValue(fetchResponse),
+    conversation: {
+      context: { get_context_for_prompt: vi.fn().mockResolvedValue(ctx) },
+    },
+    memories: {
+      create: vi.fn().mockResolvedValue({ ingestion_id: ingestionId } satisfies SynapMemoryCreateResult),
+    },
+  };
+}
+
+export function makeFailingSdk(err?: Error): SynapSdkLike {
+  const e = err ?? new Error("simulated-sdk-failure");
+  const sdk = makeSdk();
+  (sdk.fetch as ReturnType<typeof vi.fn>).mockRejectedValue(e);
+  (sdk.conversation.context.get_context_for_prompt as ReturnType<typeof vi.fn>).mockRejectedValue(e);
+  (sdk.memories.create as ReturnType<typeof vi.fn>).mockRejectedValue(e);
+  return sdk;
+}
+
+// ── eve context stub ──────────────────────────────────────────────────────────
+
+/** Minimal eve `ctx` satisfying `EveSessionLike` — authenticated by default. */
+export function makeCtx(
+  opts: { sessionId?: string; principalId?: string | null; initiatorId?: string | null } = {},
+): EveSessionLike {
+  const { sessionId = "sess-eve-1", principalId = "alice", initiatorId = null } = opts;
+  return {
+    session: {
+      id: sessionId,
+      auth: {
+        current: principalId ? { principalId } : null,
+        initiator: initiatorId ? { principalId: initiatorId } : null,
+      },
+    },
+  };
+}

--- a/packages/integrations/synap-eve/src/__tests__/short_term.test.ts
+++ b/packages/integrations/synap-eve/src/__tests__/short_term.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  fetchSynapShortTerm,
+  buildSynapShortTermMarkdown,
+  createSynapInstructions,
+} from "../short_term.js";
+import { makeSdk, makeFailingSdk, makeCtx, promptContext } from "./helpers.js";
+
+describe("fetchSynapShortTerm", () => {
+  it("returns available context (happy path)", async () => {
+    const sdk = makeSdk();
+    const res = await fetchSynapShortTerm({ sdk, conversationId: "conv-1" });
+    expect(res.available).toBe(true);
+    expect(res.formattedContext).toContain("senior engineer");
+  });
+
+  it("returns unavailable when the server reports none", async () => {
+    const sdk = makeSdk({ promptCtx: promptContext(false) });
+    const res = await fetchSynapShortTerm({ sdk, conversationId: "conv-1" });
+    expect(res).toEqual({ formattedContext: "", available: false });
+  });
+
+  it("degrades to unavailable on SDK failure with onError=fallback (default)", async () => {
+    const sdk = makeFailingSdk();
+    const res = await fetchSynapShortTerm({ sdk, conversationId: "conv-1" });
+    expect(res).toEqual({ formattedContext: "", available: false });
+  });
+
+  it("propagates the SDK error with onError=raise", async () => {
+    const sdk = makeFailingSdk();
+    await expect(
+      fetchSynapShortTerm({ sdk, conversationId: "conv-1", onError: "raise" }),
+    ).rejects.toThrow();
+  });
+
+  it("rejects an empty conversationId", async () => {
+    const sdk = makeSdk();
+    await expect(fetchSynapShortTerm({ sdk, conversationId: "" })).rejects.toBeInstanceOf(TypeError);
+  });
+
+  it("rejects an unsupported style", async () => {
+    const sdk = makeSdk();
+    await expect(
+      // @ts-expect-error — intentional bad style
+      fetchSynapShortTerm({ sdk, conversationId: "c", style: "poetic" }),
+    ).rejects.toBeInstanceOf(TypeError);
+  });
+});
+
+describe("buildSynapShortTermMarkdown", () => {
+  it("wraps body in the default preamble tags", () => {
+    const md = buildSynapShortTermMarkdown({ formattedContext: "hello", available: true });
+    expect(md).toBe("<synap_short_term_context>\nhello\n</synap_short_term_context>");
+  });
+
+  it("emits raw body when tags are nulled", () => {
+    const md = buildSynapShortTermMarkdown(
+      { formattedContext: "hello", available: true },
+      { preambleOpen: null, preambleClose: null },
+    );
+    expect(md).toBe("hello");
+  });
+
+  it("returns empty string on empty context", () => {
+    expect(buildSynapShortTermMarkdown({ formattedContext: "", available: false })).toBe("");
+  });
+});
+
+describe("createSynapInstructions (dynamic resolver)", () => {
+  // The resolver is the `turn.started` handler eve invokes; we exercise it
+  // directly with a duck-typed ctx.
+  function getResolver(def: unknown): (event: unknown, ctx: unknown) => Promise<unknown> {
+    const events = (def as { events: Record<string, unknown> }).events;
+    return events["turn.started"] as never;
+  }
+
+  it("returns a defineInstructions payload with the recalled markdown (happy path)", async () => {
+    const sdk = makeSdk();
+    const resolver = getResolver(createSynapInstructions({ sdk }));
+    const out = (await resolver({}, makeCtx({ sessionId: "conv-7" }))) as { markdown?: string } | null;
+    expect(out).not.toBeNull();
+    expect(out?.markdown).toContain("synap_short_term_context");
+    expect(sdk.conversation.context.get_context_for_prompt).toHaveBeenCalledWith(
+      expect.objectContaining({ conversation_id: "conv-7" }),
+    );
+  });
+
+  it("returns null (no-op) when there is no conversation id", async () => {
+    const sdk = makeSdk();
+    const resolver = getResolver(createSynapInstructions({ sdk }));
+    const out = await resolver({}, { session: { id: "", auth: null } });
+    expect(out).toBeNull();
+    expect(sdk.conversation.context.get_context_for_prompt).not.toHaveBeenCalled();
+  });
+
+  it("returns null (no-op) when the server reports no context", async () => {
+    const sdk = makeSdk({ promptCtx: promptContext(false) });
+    const resolver = getResolver(createSynapInstructions({ sdk }));
+    const out = await resolver({}, makeCtx());
+    expect(out).toBeNull();
+  });
+
+  it("returns null (no-op) on SDK failure — read-degrade, turn proceeds", async () => {
+    const sdk = makeFailingSdk();
+    const resolver = getResolver(createSynapInstructions({ sdk }));
+    const out = await resolver({}, makeCtx());
+    expect(out).toBeNull();
+  });
+});

--- a/packages/integrations/synap-eve/src/__tests__/tools.test.ts
+++ b/packages/integrations/synap-eve/src/__tests__/tools.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from "vitest";
+
+import { createSynapSearchTool, createSynapStoreTool } from "../tools.js";
+import { SynapIntegrationError } from "../types.js";
+import { makeSdk, makeFailingSdk, makeCtx, EMPTY } from "./helpers.js";
+
+describe("createSynapSearchTool", () => {
+  it("returns formatted context on a hit (happy path)", async () => {
+    const sdk = makeSdk();
+    const tool = createSynapSearchTool({ sdk });
+    const out = await tool.execute({ query: "what do we know about alice?" }, makeCtx() as never);
+    expect(out.available).toBe(true);
+    expect(out.formattedContext).toContain("Senior engineer");
+    expect(sdk.fetch).toHaveBeenCalledOnce();
+  });
+
+  it("auto-scopes user_id + conversation_id from the eve session", async () => {
+    const sdk = makeSdk();
+    const tool = createSynapSearchTool({ sdk });
+    await tool.execute({ query: "x" }, makeCtx({ sessionId: "conv-9", principalId: "bob" }) as never);
+    expect(sdk.fetch).toHaveBeenCalledWith(
+      expect.objectContaining({ user_id: "bob", conversation_id: "conv-9" }),
+    );
+  });
+
+  it("explicit userId overrides the eve principal", async () => {
+    const sdk = makeSdk();
+    const tool = createSynapSearchTool({ sdk, userId: "explicit" });
+    await tool.execute({ query: "x" }, makeCtx({ principalId: "bob" }) as never);
+    expect(sdk.fetch).toHaveBeenCalledWith(expect.objectContaining({ user_id: "explicit" }));
+  });
+
+  it("degrades to unavailable when no user scope is resolvable", async () => {
+    const sdk = makeSdk();
+    const tool = createSynapSearchTool({ sdk });
+    const out = await tool.execute({ query: "x" }, makeCtx({ principalId: null }) as never);
+    expect(out).toEqual({ formattedContext: "", available: false });
+    expect(sdk.fetch).not.toHaveBeenCalled();
+  });
+
+  it("does NOT fall back to the session initiator (no cross-scope leak)", async () => {
+    const sdk = makeSdk();
+    const tool = createSynapSearchTool({ sdk });
+    // current principal is null (delegated turn); initiator is an admin who
+    // started the session — must not be used as the memory scope.
+    const out = await tool.execute(
+      { query: "x" },
+      makeCtx({ principalId: null, initiatorId: "admin" }) as never,
+    );
+    expect(out).toEqual({ formattedContext: "", available: false });
+    expect(sdk.fetch).not.toHaveBeenCalled();
+  });
+
+  it("forwards customerId scoping to the SDK", async () => {
+    const sdk = makeSdk();
+    const tool = createSynapSearchTool({ sdk, customerId: "acme" });
+    await tool.execute({ query: "x" }, makeCtx() as never);
+    expect(sdk.fetch).toHaveBeenCalledWith(expect.objectContaining({ customer_id: "acme" }));
+  });
+
+  it("degrades to unavailable on empty context", async () => {
+    const sdk = makeSdk({ fetchResponse: EMPTY() });
+    const tool = createSynapSearchTool({ sdk });
+    const out = await tool.execute({ query: "x" }, makeCtx() as never);
+    expect(out).toEqual({ formattedContext: "", available: false });
+  });
+
+  it("degrades (does NOT throw) on SDK failure — reads swallow errors", async () => {
+    const sdk = makeFailingSdk();
+    const tool = createSynapSearchTool({ sdk });
+    const out = await tool.execute({ query: "x" }, makeCtx() as never);
+    expect(out).toEqual({ formattedContext: "", available: false });
+  });
+});
+
+describe("createSynapStoreTool", () => {
+  it("records a memory and returns the ingestion id (happy path)", async () => {
+    const sdk = makeSdk({ ingestionId: "ing-42" });
+    const tool = createSynapStoreTool({ sdk });
+    const out = await tool.execute({ content: "Alice prefers email" }, makeCtx() as never);
+    expect(out).toEqual({ recorded: true, ingestionId: "ing-42" });
+    expect(sdk.memories.create).toHaveBeenCalledWith(
+      expect.objectContaining({ document: "Alice prefers email", user_id: "alice" }),
+    );
+  });
+
+  it("stamps source=eve into metadata (caller metadata wins)", async () => {
+    const sdk = makeSdk();
+    const tool = createSynapStoreTool({ sdk });
+    await tool.execute({ content: "note", metadata: { tag: "x" } }, makeCtx() as never);
+    expect(sdk.memories.create).toHaveBeenCalledWith(
+      expect.objectContaining({ metadata: { source: "eve", tag: "x" } }),
+    );
+  });
+
+  it("raises SynapIntegrationError on SDK failure — writes never drop", async () => {
+    const sdk = makeFailingSdk();
+    const tool = createSynapStoreTool({ sdk });
+    await expect(tool.execute({ content: "note" }, makeCtx() as never)).rejects.toBeInstanceOf(
+      SynapIntegrationError,
+    );
+  });
+
+  it("raises SynapIntegrationError on missing content", async () => {
+    const sdk = makeSdk();
+    const tool = createSynapStoreTool({ sdk });
+    await expect(tool.execute({ content: "  " }, makeCtx() as never)).rejects.toBeInstanceOf(
+      SynapIntegrationError,
+    );
+    expect(sdk.memories.create).not.toHaveBeenCalled();
+  });
+
+  it("raises SynapIntegrationError when no user scope is resolvable", async () => {
+    const sdk = makeSdk();
+    const tool = createSynapStoreTool({ sdk });
+    await expect(
+      tool.execute({ content: "note" }, makeCtx({ principalId: null }) as never),
+    ).rejects.toBeInstanceOf(SynapIntegrationError);
+    expect(sdk.memories.create).not.toHaveBeenCalled();
+  });
+});

--- a/packages/integrations/synap-eve/src/index.ts
+++ b/packages/integrations/synap-eve/src/index.ts
@@ -9,7 +9,7 @@
  *     `agent/instructions/*.ts`, injecting Synap's compacted summary into the
  *     system prompt.
  *
- * Identity auto-scopes from the eve session (`ctx.session.auth.principalId`,
+ * Identity auto-scopes from the eve session (`ctx.session.auth.current.principalId`,
  * `ctx.session.id`), with explicit overrides for unauthenticated channels.
  */
 

--- a/packages/integrations/synap-eve/src/index.ts
+++ b/packages/integrations/synap-eve/src/index.ts
@@ -1,0 +1,51 @@
+/**
+ * Synap memory integration for Vercel eve agents.
+ *
+ * Two surfaces, both authored under an eve `agent/` directory:
+ *
+ *   - `createSynapSearchTool` / `createSynapStoreTool` — explicit recall/store
+ *     tools for `agent/tools/*.ts` (the filename becomes the tool name).
+ *   - `createSynapInstructions` — a per-turn short-term-context resolver for
+ *     `agent/instructions/*.ts`, injecting Synap's compacted summary into the
+ *     system prompt.
+ *
+ * Identity auto-scopes from the eve session (`ctx.session.auth.principalId`,
+ * `ctx.session.id`), with explicit overrides for unauthenticated channels.
+ */
+
+export {
+  createSynapSearchTool,
+  createSynapStoreTool,
+} from "./tools.js";
+export type { SynapToolOptions } from "./tools.js";
+
+export {
+  createSynapInstructions,
+  fetchSynapShortTerm,
+  buildSynapShortTermMarkdown,
+} from "./short_term.js";
+export type {
+  SynapShortTermStyle,
+  SynapShortTermOnError,
+  SynapShortTermResult,
+  FetchSynapShortTermOptions,
+  BuildSynapShortTermMarkdownOptions,
+  SynapInstructionsOptions,
+} from "./short_term.js";
+
+export {
+  SynapIntegrationError,
+  resolveUserId,
+  resolveConversationId,
+} from "./types.js";
+export type {
+  SynapSdkLike,
+  SynapFetchArgs,
+  SynapFetchResponseLike,
+  SynapMemoryCreateArgs,
+  SynapMemoryCreateResult,
+  SynapPromptContext,
+  SynapRecentMessage,
+  EveSessionLike,
+  EveAuthContextLike,
+} from "./types.js";

--- a/packages/integrations/synap-eve/src/short_term.ts
+++ b/packages/integrations/synap-eve/src/short_term.ts
@@ -1,0 +1,155 @@
+// Synap short-term context for eve agents.
+//
+// eve's own durability (Vercel Workflows event-log replay) persists a single
+// session's turn state; it is not cross-session recall and it does not surface
+// Synap's compacted short-term summary. This module injects that summary into
+// the system prompt as a first-class eve extension point.
+//
+// `createSynapInstructions` returns a `defineDynamic` resolver for
+// `agent/instructions/`, evaluated at `turn.started`. It *augments* the system
+// prompt (eve lowers each `defineInstructions` to one extra `{ role: "system" }`
+// message) — it never replaces `instructions.md` or the user's turn.
+//
+//   // agent/instructions/synap.ts
+//   import { createSynapInstructions } from "@maximem/synap-eve";
+//   import { sdk } from "../lib/synap.js";
+//   export default createSynapInstructions({ sdk });
+//
+// Error policy: reads degrade. On no content, missing conversation id, or an
+// SDK failure with the default `onError: "fallback"`, the resolver returns
+// `null`, which eve treats as "contribute nothing" — the turn proceeds.
+
+import { defineDynamic } from "eve/tools";
+import { defineInstructions } from "eve/instructions";
+
+import {
+  resolveConversationId,
+  type EveSessionLike,
+  type SynapSdkLike,
+} from "./types.js";
+
+const SUPPORTED_STYLES = ["structured", "narrative", "bullet_points"] as const;
+export type SynapShortTermStyle = (typeof SUPPORTED_STYLES)[number];
+
+export type SynapShortTermOnError = "fallback" | "raise";
+
+const DEFAULT_PREAMBLE_OPEN = "<synap_short_term_context>";
+const DEFAULT_PREAMBLE_CLOSE = "</synap_short_term_context>";
+
+export interface SynapShortTermResult {
+  /** The short-term string ready to splice into a system prompt. Empty if none. */
+  formattedContext: string;
+  /** Whether the server reported any short-term context (compaction or recent turns). */
+  available: boolean;
+}
+
+export interface FetchSynapShortTermOptions {
+  sdk: SynapSdkLike;
+  conversationId: string;
+  style?: SynapShortTermStyle;
+  /** Defaults to 'fallback'. */
+  onError?: SynapShortTermOnError;
+}
+
+/**
+ * Fetch Synap short-term context for `conversationId`.
+ *
+ * Returns `{ formattedContext: '', available: false }` on no content, and also
+ * on SDK failure with the default `onError: 'fallback'`.
+ *
+ * @throws if `conversationId` is empty or `style` is unknown.
+ * @throws the underlying SDK error when `onError: 'raise'`.
+ */
+export async function fetchSynapShortTerm(
+  opts: FetchSynapShortTermOptions,
+): Promise<SynapShortTermResult> {
+  const { sdk, conversationId } = opts;
+  if (!sdk) throw new TypeError("fetchSynapShortTerm requires a non-null sdk");
+  if (!conversationId || !conversationId.trim()) {
+    throw new TypeError("fetchSynapShortTerm requires a non-empty conversationId");
+  }
+  const style: SynapShortTermStyle = opts.style ?? "narrative";
+  if (!SUPPORTED_STYLES.includes(style)) {
+    throw new TypeError(
+      `fetchSynapShortTerm: unsupported style=${JSON.stringify(style)}; expected one of ${SUPPORTED_STYLES.join(", ")}`,
+    );
+  }
+  const onError: SynapShortTermOnError = opts.onError ?? "fallback";
+  try {
+    const response = await sdk.conversation.context.get_context_for_prompt({
+      conversation_id: conversationId,
+      style,
+    });
+    if (!response.available) return { formattedContext: "", available: false };
+    return {
+      formattedContext: (response.formatted_context ?? "").trim(),
+      available: response.available,
+    };
+  } catch (err) {
+    if (onError === "raise") throw err;
+    console.warn("[synap-eve] fetchSynapShortTerm failed:", (err as Error).message ?? err);
+    return { formattedContext: "", available: false };
+  }
+}
+
+export interface BuildSynapShortTermMarkdownOptions {
+  /** Wrapping tags. Pass `null` to drop the wrapper. */
+  preambleOpen?: string | null;
+  preambleClose?: string | null;
+}
+
+/**
+ * Wrap a short-term result as markdown for a `defineInstructions` message.
+ * Returns the empty string when there is no context — the caller emits `null`.
+ */
+export function buildSynapShortTermMarkdown(
+  result: SynapShortTermResult,
+  opts: BuildSynapShortTermMarkdownOptions = {},
+): string {
+  const body = (result.formattedContext ?? "").trim();
+  if (!body) return "";
+  const open = opts.preambleOpen === undefined ? DEFAULT_PREAMBLE_OPEN : opts.preambleOpen;
+  const close = opts.preambleClose === undefined ? DEFAULT_PREAMBLE_CLOSE : opts.preambleClose;
+  return open && close ? `${open}\n${body}\n${close}` : body;
+}
+
+export interface SynapInstructionsOptions extends BuildSynapShortTermMarkdownOptions {
+  sdk: SynapSdkLike;
+  /** Explicit conversation id. Defaults to the eve session id (`ctx.session.id`). */
+  conversationId?: string;
+  style?: SynapShortTermStyle;
+  /** Defaults to 'fallback' — a recall failure degrades to no injected context. */
+  onError?: SynapShortTermOnError;
+}
+
+/**
+ * Build the per-turn Synap short-term instructions resolver for
+ * `agent/instructions/`. Evaluated at `turn.started`; returns
+ * `defineInstructions({ markdown })` when there is context, else `null`.
+ */
+export function createSynapInstructions(options: SynapInstructionsOptions) {
+  const { sdk } = options;
+  if (!sdk) throw new TypeError("createSynapInstructions requires a non-null sdk");
+
+  const resolve = async (_event: unknown, ctx: EveSessionLike) => {
+    const conversationId = resolveConversationId(options.conversationId, ctx);
+    if (!conversationId) return null;
+    const result = await fetchSynapShortTerm({
+      sdk,
+      conversationId,
+      style: options.style,
+      onError: options.onError,
+    });
+    const markdown = buildSynapShortTermMarkdown(result, {
+      preambleOpen: options.preambleOpen,
+      preambleClose: options.preambleClose,
+    });
+    return markdown ? defineInstructions({ markdown }) : null;
+  };
+
+  return defineDynamic({
+    events: {
+      "turn.started": resolve,
+    },
+  });
+}

--- a/packages/integrations/synap-eve/src/tools.ts
+++ b/packages/integrations/synap-eve/src/tools.ts
@@ -9,7 +9,7 @@
 //   import { sdk } from "../lib/synap.js";
 //   export default createSynapSearchTool({ sdk });
 //
-// Identity is auto-scoped from the eve session (`ctx.session.auth.principalId`),
+// Identity is auto-scoped from the eve session (`ctx.session.auth.current.principalId`),
 // with an explicit `userId` override for unauthenticated channels.
 //
 // Error policy: reads (search) degrade to an empty result; writes (store) raise
@@ -29,7 +29,15 @@ import {
 export interface SynapToolOptions {
   /** Configured Synap SDK. */
   sdk: SynapSdkLike;
-  /** Explicit Synap user scope. Overrides the eve principal; required on unauthenticated channels. */
+  /**
+   * Explicit Synap user scope. Required on unauthenticated channels, where
+   * `ctx.session.auth.current` is `null`.
+   *
+   * This *overrides* the eve principal — it is not a fallback. Because the
+   * factories are called once per `agent/tools/*.ts` module, setting it on an
+   * authenticated multi-user agent pins every session to the same scope. Leave
+   * it unset wherever the session carries a real principal.
+   */
   userId?: string;
   /** Optional customer/org scope. */
   customerId?: string;

--- a/packages/integrations/synap-eve/src/tools.ts
+++ b/packages/integrations/synap-eve/src/tools.ts
@@ -1,0 +1,154 @@
+// Synap tools for eve agents.
+//
+// Each factory returns an eve `ToolDefinition` (branded by `defineTool`) meant
+// to be the default export of a file under `agent/tools/`, where the filename
+// becomes the model-facing tool name:
+//
+//   // agent/tools/synap_search.ts
+//   import { createSynapSearchTool } from "@maximem/synap-eve";
+//   import { sdk } from "../lib/synap.js";
+//   export default createSynapSearchTool({ sdk });
+//
+// Identity is auto-scoped from the eve session (`ctx.session.auth.principalId`),
+// with an explicit `userId` override for unauthenticated channels.
+//
+// Error policy: reads (search) degrade to an empty result; writes (store) raise
+// `SynapIntegrationError` so ingestion outages are observable to the agent.
+
+import { defineTool } from "eve/tools";
+import { z } from "zod";
+
+import {
+  SynapIntegrationError,
+  resolveUserId,
+  resolveConversationId,
+  type EveSessionLike,
+  type SynapSdkLike,
+} from "./types.js";
+
+export interface SynapToolOptions {
+  /** Configured Synap SDK. */
+  sdk: SynapSdkLike;
+  /** Explicit Synap user scope. Overrides the eve principal; required on unauthenticated channels. */
+  userId?: string;
+  /** Optional customer/org scope. */
+  customerId?: string;
+  /** Explicit conversation id. Defaults to the eve session id. */
+  conversationId?: string;
+  /** Synap fetch mode ("accurate" default, or "fast"). */
+  mode?: string;
+}
+
+const searchInput = z.object({
+  query: z.string().describe("What to look up in the user's memory"),
+  maxResults: z
+    .number()
+    .int()
+    .positive()
+    .optional()
+    .describe("Maximum number of results (default 10)"),
+});
+
+const storeInput = z.object({
+  content: z.string().describe("The fact, preference, or note to persist"),
+  metadata: z
+    .record(z.string(), z.unknown())
+    .optional()
+    .describe("Optional metadata to attach"),
+});
+
+/**
+ * Read tool: search the user's Synap memory for context relevant to a query.
+ * Degrades to `{ available: false }` on missing identity or SDK failure — a
+ * recall miss never aborts the turn.
+ */
+export function createSynapSearchTool(options: SynapToolOptions) {
+  const { sdk } = options;
+  if (!sdk) throw new TypeError("createSynapSearchTool requires a non-null sdk");
+
+  return defineTool({
+    description:
+      "Search the user's long-term Synap memory (facts, preferences, " +
+      "episodes, emotions, temporal events) for context relevant to a " +
+      "query. Use when you need background about the user that is not in " +
+      "the current conversation.",
+    inputSchema: searchInput,
+    outputSchema: z.object({
+      formattedContext: z.string(),
+      available: z.boolean(),
+    }),
+    async execute(input, ctx) {
+      const query = (input?.query ?? "").trim();
+      const maxResults = input?.maxResults ?? 10;
+      const userId = resolveUserId(options.userId, ctx as EveSessionLike);
+      if (!query || !userId) {
+        return { formattedContext: "", available: false };
+      }
+      try {
+        const response = await sdk.fetch({
+          conversation_id: resolveConversationId(options.conversationId, ctx as EveSessionLike) ?? null,
+          user_id: userId,
+          customer_id: options.customerId || null,
+          search_query: [query],
+          max_results: maxResults,
+          mode: options.mode ?? "accurate",
+          include_conversation_context: false,
+        });
+        const text = (response.formatted_context ?? "").trim();
+        return { formattedContext: text, available: !!text };
+      } catch (err) {
+        console.error(`[synap-eve] synap_search failed userId=${userId}:`, err);
+        return { formattedContext: "", available: false };
+      }
+    },
+  });
+}
+
+/**
+ * Write tool: persist an explicit fact/preference/note to Synap for future
+ * recall. Raises `SynapIntegrationError` on failure (writes never silently
+ * drop) — eve surfaces the error result to the model.
+ */
+export function createSynapStoreTool(options: SynapToolOptions) {
+  const { sdk } = options;
+  if (!sdk) throw new TypeError("createSynapStoreTool requires a non-null sdk");
+
+  return defineTool({
+    description:
+      "Persist an explicit fact, preference, or note to the user's Synap " +
+      "memory for future recall. Call this when the user shares something " +
+      "worth remembering across sessions.",
+    inputSchema: storeInput,
+    outputSchema: z.object({
+      recorded: z.boolean(),
+      ingestionId: z.string().optional(),
+    }),
+    async execute(input, ctx) {
+      const content = (input?.content ?? "").trim();
+      const userId = resolveUserId(options.userId, ctx as EveSessionLike);
+      if (!content) {
+        throw new SynapIntegrationError("synap_store", "missing content");
+      }
+      if (!userId) {
+        throw new SynapIntegrationError(
+          "synap_store",
+          "no user scope (authenticate the channel or pass userId)",
+        );
+      }
+      const metadata: Record<string, unknown> = { source: "eve", ...(input?.metadata ?? {}) };
+      try {
+        const result = await sdk.memories.create({
+          document: content,
+          user_id: userId,
+          customer_id: options.customerId || null,
+          metadata,
+        });
+        return { recorded: true, ingestionId: result.ingestion_id ?? "" };
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.error(`[synap-eve] synap_store failed userId=${userId}:`, err);
+        throw new SynapIntegrationError("synap_store", msg, err);
+      }
+    },
+  });
+}

--- a/packages/integrations/synap-eve/src/types.ts
+++ b/packages/integrations/synap-eve/src/types.ts
@@ -1,0 +1,143 @@
+// Duck-typed Synap SDK surface + eve session-context shape.
+//
+// Following the TS-integration convention (see synap-vercel-adk / synap-mastra):
+// we do NOT import the real `@maximem/synap-js-sdk` type. Production users pass
+// the real SDK; smoke tests pass a mock conforming to `SynapSdkLike`. The eve
+// runtime context is likewise duck-typed (`EveSessionLike`) so surface code and
+// tests never depend on eve's internal type graph — only the two public entry
+// points (`eve/tools`, `eve/instructions`) are imported for real.
+
+// ── Synap SDK (duck-typed) ────────────────────────────────────────────────────
+
+export interface SynapFetchResponseLike {
+  formatted_context?: string | null;
+  facts?: unknown[];
+  preferences?: unknown[];
+  episodes?: unknown[];
+  emotions?: unknown[];
+  temporal_events?: unknown[];
+}
+
+export interface SynapFetchArgs {
+  conversation_id?: string | null;
+  user_id: string;
+  customer_id?: string | null;
+  search_query?: string[] | null;
+  max_results?: number;
+  mode?: string;
+  include_conversation_context?: boolean;
+}
+
+export interface SynapMemoryCreateArgs {
+  document: string;
+  user_id: string;
+  customer_id?: string | null;
+  metadata?: Record<string, unknown>;
+}
+
+export interface SynapMemoryCreateResult {
+  ingestion_id: string;
+}
+
+export interface SynapRecentMessage {
+  role: string;
+  content: string;
+  timestamp: string;
+  message_id: string;
+}
+
+export interface SynapPromptContext {
+  formatted_context: string;
+  available: boolean;
+  recent_messages: SynapRecentMessage[];
+  recent_message_count: number;
+  total_message_count: number;
+}
+
+export interface SynapSdkLike {
+  fetch(args: SynapFetchArgs): Promise<SynapFetchResponseLike>;
+  conversation: {
+    context: {
+      get_context_for_prompt(args: {
+        conversation_id: string;
+        /** Optional formatting style — structured | narrative | bullet_points. */
+        style?: string;
+      }): Promise<SynapPromptContext>;
+    };
+  };
+  memories: {
+    create(args: SynapMemoryCreateArgs): Promise<SynapMemoryCreateResult>;
+  };
+}
+
+// ── eve runtime context (duck-typed) ──────────────────────────────────────────
+//
+// Mirrors eve's `SessionContext.session` / `DynamicResolveContext.session`
+// (id + auth), and `SessionAuth` (current + initiator `SessionAuthContext`).
+// Both a tool's `ctx` and an instructions resolver's `ctx` satisfy this.
+
+export interface EveAuthContextLike {
+  readonly principalId?: string;
+  readonly subject?: string;
+}
+
+export interface EveSessionLike {
+  readonly session: {
+    readonly id: string;
+    readonly auth?: {
+      readonly current?: EveAuthContextLike | null;
+      readonly initiator?: EveAuthContextLike | null;
+    } | null;
+  };
+}
+
+// ── Error policy ──────────────────────────────────────────────────────────────
+//
+// The TS packages have no shared `synap-integrations-common`, so we re-declare
+// the error type locally (same contract as the Python integrations):
+//   reads degrade → [] / empty; writes raise; deletes warn + no-op.
+
+export class SynapIntegrationError extends Error {
+  readonly operation: string;
+  readonly cause?: unknown;
+
+  constructor(operation: string, message: string, cause?: unknown) {
+    super(`${operation}: ${message}`);
+    this.name = "SynapIntegrationError";
+    this.operation = operation;
+    this.cause = cause;
+  }
+}
+
+// ── Identity resolution ───────────────────────────────────────────────────────
+
+/**
+ * Resolve the Synap user scope for a turn. Prefers an explicit id, then the
+ * turn's *current* principal. Returns `undefined` when neither is present —
+ * callers apply the read/write policy accordingly.
+ *
+ * Deliberately does NOT fall back to `auth.initiator`: on a delegated or
+ * system-initiated session `initiator` is whoever *started* the session (e.g.
+ * an admin/service), not the end user this turn acts for — using it would scope
+ * memory to the wrong principal. When `current` is null (unauthenticated
+ * channel), pass an explicit `userId` instead.
+ */
+export function resolveUserId(
+  explicit: string | undefined,
+  ctx?: EveSessionLike,
+): string | undefined {
+  if (explicit && explicit.trim()) return explicit;
+  const principal = ctx?.session?.auth?.current?.principalId;
+  if (principal && principal.trim()) return principal;
+  return undefined;
+}
+
+/** Resolve the conversation scope: explicit id, else the eve session id. */
+export function resolveConversationId(
+  explicit: string | undefined,
+  ctx?: EveSessionLike,
+): string | undefined {
+  if (explicit && explicit.trim()) return explicit;
+  const id = ctx?.session?.id;
+  return id && id.trim() ? id : undefined;
+}

--- a/packages/integrations/synap-eve/tsconfig.json
+++ b/packages/integrations/synap-eve/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/integrations/synap-eve/vitest.config.ts
+++ b/packages/integrations/synap-eve/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+  },
+});

--- a/packages/integrations/synap-smolagents/README.md
+++ b/packages/integrations/synap-smolagents/README.md
@@ -1,0 +1,62 @@
+# maximem-synap-smolagents
+
+Synap memory integration for [Smolagents](https://github.com/huggingface/smolagents)
+— give a `CodeAgent` / `ToolCallingAgent` persistent memory through Synap.
+
+```bash
+pip install maximem-synap-smolagents smolagents
+```
+
+## Surfaces
+
+Smolagents keeps its own fixed step log (no pluggable memory backend), so Synap plugs
+into the two extension points it *does* expose, plus static instructions:
+
+| Surface | Smolagents extension point | Purpose |
+|---------|----------------------------|---------|
+| `create_synap_tools` | `@tool` | Explicit `search_memory` / `store_memory` the model can call |
+| `create_synap_recorder` | `step_callbacks={ActionStep: ...}` | Record each completed action into Synap |
+| `synap_st_instructions` | `CodeAgent(instructions=...)` | Fold Synap short-term context into the agent's instructions |
+
+## Example
+
+```python
+from smolagents import CodeAgent, InferenceClientModel
+from smolagents.memory import ActionStep
+from maximem_synap import MaximemSynapSDK
+from synap_smolagents import create_synap_tools, create_synap_recorder, synap_st_instructions
+
+sdk = MaximemSynapSDK(api_key="sk-...")
+
+agent = CodeAgent(
+    model=InferenceClientModel(),
+    tools=create_synap_tools(sdk, user_id="alice", customer_id="acme"),
+    instructions=synap_st_instructions(
+        sdk, conversation_id="conv_abc",
+        instructions="You are a concise, friendly assistant.",
+    ),
+    step_callbacks={
+        ActionStep: create_synap_recorder(
+            sdk, user_id="alice", conversation_id="conv_abc", customer_id="acme"
+        )
+    },
+)
+agent.run("Remind me what plan I'm on and my open ticket.")
+```
+
+Because `CodeAgent` calls tools as plain Python, `search_memory` / `store_memory`
+compose naturally into agent-written code.
+
+## Notes
+
+- **Synchronous framework.** Smolagents runs synchronously and its tools do not
+  support `async`, so every surface bridges to the async Synap SDK internally. Run
+  the agent on its own thread if your app is otherwise async.
+- **Error policy.** The `search_memory` tool degrades (returns a not-found message);
+  `store_memory` raises `SynapIntegrationError`; the recorder **logs and never
+  raises** — it runs inside the agent loop, where a raising callback would abort the
+  run.
+- **Per-step documents.** The recorder writes each `ActionStep` to its own Synap
+  document, so multi-step runs are captured in full.
+
+Requires Python 3.11+ and `smolagents>=1.26`.

--- a/packages/integrations/synap-smolagents/pyproject.toml
+++ b/packages/integrations/synap-smolagents/pyproject.toml
@@ -1,0 +1,35 @@
+[build-system]
+requires = ["setuptools>=61.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "maximem-synap-smolagents"
+version = "0.1.0"
+description = "Synap memory integration for Smolagents — memory tools and a turn recorder"
+readme = "README.md"
+requires-python = ">=3.11"
+license = "Apache-2.0"
+authors = [
+    {name = "Synap Team"}
+]
+keywords = ["synap", "memory", "smolagents", "ai", "agents"]
+
+dependencies = [
+    "maximem-synap>=0.2.0",
+    "maximem-synap-integrations-common>=0.1.0",
+    "smolagents>=1.26",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.0",
+    "pytest-asyncio>=0.21",
+]
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["synap_smolagents*"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+asyncio_mode = "auto"

--- a/packages/integrations/synap-smolagents/synap_smolagents/__init__.py
+++ b/packages/integrations/synap-smolagents/synap_smolagents/__init__.py
@@ -1,0 +1,49 @@
+"""Synap memory integration for Smolagents.
+
+Hugging Face's Smolagents keeps its own fixed step log (`AgentMemory`) with no
+pluggable backend, so Synap plugs in through the two extension points Smolagents
+*does* expose:
+
+- **Tools** (`@tool`): `create_synap_tools` returns `search_memory` / `store_memory`
+  functions the model can call — idiomatic for `CodeAgent`, which invokes tools as
+  plain Python.
+- **Step callbacks**: `create_synap_recorder` returns a callback for
+  `step_callbacks={ActionStep: ...}` that records each completed action into Synap
+  for future recall.
+
+Plus `synap_st_instructions` to fold Synap short-term context into the agent's
+static `instructions`.
+
+Smolagents is synchronous and its tools do not support `async`, so every surface
+drives the async Synap SDK through the shared `run_async` bridge.
+
+Typical wiring::
+
+    from smolagents import CodeAgent, InferenceClientModel
+    from smolagents.memory import ActionStep
+    from maximem_synap import MaximemSynapSDK
+    from synap_smolagents import create_synap_tools, create_synap_recorder
+
+    sdk = MaximemSynapSDK(api_key="sk-...")
+    agent = CodeAgent(
+        model=InferenceClientModel(),
+        tools=create_synap_tools(sdk, user_id="alice", customer_id="acme"),
+        step_callbacks={ActionStep: create_synap_recorder(
+            sdk, user_id="alice", conversation_id="conv_abc")},
+    )
+    agent.run("What did we decide about the rollout?")
+
+Tools/reads degrade (a Synap blip returns a not-found message); the ``store_memory``
+tool raises ``SynapIntegrationError``; the recorder logs and never raises (it runs
+inside the agent loop, where a raising callback would abort the run).
+"""
+
+from synap_smolagents.callbacks import create_synap_recorder
+from synap_smolagents.short_term import synap_st_instructions
+from synap_smolagents.tools import create_synap_tools
+
+__all__ = [
+    "create_synap_tools",
+    "create_synap_recorder",
+    "synap_st_instructions",
+]

--- a/packages/integrations/synap-smolagents/synap_smolagents/callbacks.py
+++ b/packages/integrations/synap-smolagents/synap_smolagents/callbacks.py
@@ -1,0 +1,102 @@
+"""Synap turn recorder for Smolagents.
+
+`create_synap_recorder` returns a callback for
+``step_callbacks={ActionStep: create_synap_recorder(...)}``. Smolagents fires it at
+the end of every completed step; the recorder ingests the step's output into Synap
+so future sessions can recall what the agent did.
+
+Two behaviours are load-bearing:
+
+- **Per-step ``document_id``.** Each step is its own memory document
+  (``smolagents-{conversation_id}-{step_number}``); a single stable id would clobber
+  each step down to the last.
+- **Log, never raise.** The recorder runs inside the agent loop, in a ``finally``
+  with no surrounding try/except, so a raising callback would abort the whole run. A
+  failed ingest is logged at ERROR and swallowed — same contract as the Strands
+  stream hook.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Callable, Optional
+
+from maximem_synap import MaximemSynapSDK
+from synap_integrations_common import run_async
+
+logger = logging.getLogger(__name__)
+
+_MARKER = "smolagents_step"
+
+
+def _as_text(output: Any) -> str:
+    """Coerce an ``ActionStep.model_output`` (``str | list[dict] | None``) to text."""
+    if output is None:
+        return ""
+    if isinstance(output, str):
+        return output
+    if isinstance(output, list):
+        parts = []
+        for item in output:
+            if isinstance(item, dict):
+                parts.append(item.get("text") or item.get("content") or json.dumps(item))
+            else:
+                parts.append(str(item))
+        return "\n".join(p for p in parts if p)
+    return str(output)
+
+
+def create_synap_recorder(
+    sdk: MaximemSynapSDK,
+    user_id: str,
+    conversation_id: str,
+    *,
+    customer_id: str = "",
+) -> Callable[..., None]:
+    """Build a Smolagents step callback that records each action into Synap.
+
+    Args:
+        sdk: Configured :class:`MaximemSynapSDK`.
+        user_id: Synap user scope. **Required.**
+        conversation_id: Conversation id; seeds each step's document id. **Required.**
+        customer_id: Optional customer/org scope; empty means customer-less.
+
+    Returns:
+        A callable ``recorder(memory_step, agent=None)`` for ``step_callbacks``.
+    """
+    if sdk is None:
+        raise ValueError("create_synap_recorder requires a non-None sdk")
+    if not user_id or not str(user_id).strip():
+        raise ValueError("create_synap_recorder requires a non-empty user_id")
+    if not conversation_id or not str(conversation_id).strip():
+        raise ValueError("create_synap_recorder requires a non-empty conversation_id")
+
+    def recorder(memory_step: Any, agent: Optional[Any] = None) -> None:
+        # Skip failed steps — the callback fires for them too.
+        if getattr(memory_step, "error", None) is not None:
+            return
+        text = _as_text(getattr(memory_step, "model_output", None)).strip()
+        if not text:
+            return
+        step_number = getattr(memory_step, "step_number", 0)
+        try:
+            run_async(
+                sdk.memories.create(
+                    document=text,
+                    user_id=user_id,
+                    customer_id=customer_id or None,
+                    document_type="ai-chat-conversation",
+                    document_id=f"smolagents-{conversation_id}-{step_number}",
+                    metadata={_MARKER: True, "step": step_number},
+                )
+            )
+        except Exception as exc:  # noqa: BLE001 — in-loop callback: log, never raise
+            logger.error(
+                "SynapStepRecorder: ingest failed step=%s error=%s",
+                step_number,
+                exc,
+                exc_info=True,
+            )
+
+    return recorder

--- a/packages/integrations/synap-smolagents/synap_smolagents/short_term.py
+++ b/packages/integrations/synap-smolagents/synap_smolagents/short_term.py
@@ -1,0 +1,149 @@
+"""Synap short-term context for Smolagents.
+
+Smolagents `CodeAgent(instructions=...)` / `ToolCallingAgent(instructions=...)` take
+a static string, so short-term context is folded into `instructions` once, at
+construction, via `sdk.conversation.context.get_context_for_prompt`. Returns the
+composed instructions string.
+
+Quality contract (mirrors the other Synap integrations):
+
+- ``conversation_id`` required + explicit.
+- SDK failures never crash construction by default (``on_error="fallback"``): the
+  bare ``instructions`` are returned.
+- Empty short-term context is a no-op — the user's ``instructions`` are untouched.
+- ``on_error="raise"`` propagates :class:`SynapIntegrationError` for strict setups.
+
+Because the context is fetched once at construction, it is a snapshot; rebuild the
+agent (or re-call this) to refresh it.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Literal, Optional
+
+from maximem_synap import MaximemSynapSDK
+from synap_integrations_common import (
+    SynapIntegrationError,
+    run_async,
+    wrap_sdk_errors_async,
+)
+
+logger = logging.getLogger(__name__)
+
+_SUPPORTED_STYLES = ("structured", "narrative", "bullet_points")
+_DEFAULT_OPEN = "<synap_short_term_context>"
+_DEFAULT_CLOSE = "</synap_short_term_context>"
+
+_OnError = Literal["fallback", "raise"]
+
+
+def _validate_args(
+    sdk: Optional[MaximemSynapSDK],
+    conversation_id: str,
+    style: str,
+    on_error: str,
+) -> None:
+    if sdk is None:
+        raise ValueError("synap_st_instructions requires a non-None sdk")
+    if not conversation_id or not str(conversation_id).strip():
+        raise ValueError("synap_st_instructions requires a non-empty conversation_id")
+    if style not in _SUPPORTED_STYLES:
+        raise ValueError(
+            f"synap_st_instructions: unsupported style={style!r}; "
+            f"expected one of {_SUPPORTED_STYLES}"
+        )
+    if on_error not in ("fallback", "raise"):
+        raise ValueError(
+            f"synap_st_instructions: on_error must be 'fallback' or 'raise', "
+            f"got {on_error!r}"
+        )
+
+
+async def _fetch_st_block(
+    sdk: MaximemSynapSDK,
+    conversation_id: str,
+    style: str,
+    on_error: _OnError,
+) -> str:
+    try:
+        async with wrap_sdk_errors_async(
+            "smolagents.synap_st_instructions",
+            logger,
+            conversation_id=conversation_id,
+            style=style,
+        ):
+            response = await sdk.conversation.context.get_context_for_prompt(
+                conversation_id=conversation_id,
+                style=style,
+            )
+    except SynapIntegrationError:
+        if on_error == "raise":
+            raise
+        return ""
+    if not getattr(response, "available", False):
+        return ""
+    return (getattr(response, "formatted_context", None) or "").strip()
+
+
+def _compose(
+    st_block: str,
+    instructions: str,
+    preamble_open: Optional[str],
+    preamble_close: Optional[str],
+) -> str:
+    parts = []
+    st_block = (st_block or "").strip()
+    instructions = (instructions or "").strip()
+    if st_block:
+        if preamble_open and preamble_close:
+            parts.append(f"{preamble_open}\n{st_block}\n{preamble_close}")
+        else:
+            parts.append(st_block)
+    if instructions:
+        parts.append(instructions)
+    return "\n\n".join(parts)
+
+
+def synap_st_instructions(
+    sdk: MaximemSynapSDK,
+    conversation_id: str,
+    *,
+    instructions: str = "",
+    style: str = "narrative",
+    preamble_open: Optional[str] = _DEFAULT_OPEN,
+    preamble_close: Optional[str] = _DEFAULT_CLOSE,
+    on_error: _OnError = "fallback",
+) -> str:
+    """Compose Smolagents ``instructions`` with Synap short-term context prepended.
+
+    Args:
+        sdk: Initialised :class:`MaximemSynapSDK`.
+        conversation_id: Synap conversation id. **Required.**
+        instructions: Your own static instructions; ST is prepended above them.
+        style: One of ``"structured" | "narrative" | "bullet_points"``.
+        preamble_open / preamble_close: ST block wrappers; pass ``None`` for both to
+            drop the tags.
+        on_error: ``"fallback"`` (default) returns the bare ``instructions`` on SDK
+            failure; ``"raise"`` propagates :class:`SynapIntegrationError`.
+
+    Returns:
+        The composed instructions string for ``CodeAgent(instructions=...)``.
+
+    Example::
+
+        from smolagents import CodeAgent, InferenceClientModel
+        from synap_smolagents import synap_st_instructions
+
+        agent = CodeAgent(
+            model=InferenceClientModel(),
+            tools=[],
+            instructions=synap_st_instructions(
+                sdk, conversation_id="conv_abc",
+                instructions="You are a helpful assistant.",
+            ),
+        )
+    """
+    _validate_args(sdk, conversation_id, style, on_error)
+    st_block = run_async(_fetch_st_block(sdk, conversation_id, style, on_error))
+    return _compose(st_block, instructions, preamble_open, preamble_close)

--- a/packages/integrations/synap-smolagents/synap_smolagents/tools.py
+++ b/packages/integrations/synap-smolagents/synap_smolagents/tools.py
@@ -1,0 +1,94 @@
+"""Synap memory tools for Smolagents agents.
+
+`create_synap_tools` returns two Smolagents `@tool` functions — `search_memory` and
+`store_memory` — that the model can call. Especially idiomatic for `CodeAgent`,
+which invokes tools as plain Python calls.
+
+Smolagents tools are synchronous (async `forward` is not supported), so each tool
+drives the async Synap SDK through `run_async`. Reads degrade (return a not-found
+message); the write raises `SynapIntegrationError` so a failed store is observable.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import List
+
+from smolagents import tool
+from maximem_synap import MaximemSynapSDK
+from synap_integrations_common import run_async, wrap_sdk_errors
+
+logger = logging.getLogger(__name__)
+
+
+def create_synap_tools(
+    sdk: MaximemSynapSDK,
+    user_id: str,
+    *,
+    customer_id: str = "",
+) -> List:
+    """Build `search_memory` and `store_memory` tools bound to a Synap scope.
+
+    Args:
+        sdk: Configured :class:`MaximemSynapSDK`.
+        user_id: Synap user scope. **Required.**
+        customer_id: Optional customer/org scope; empty means customer-less.
+
+    Returns:
+        A list ``[search_memory, store_memory]`` of Smolagents tools.
+    """
+    if sdk is None:
+        raise ValueError("create_synap_tools requires a non-None sdk")
+    if not user_id or not str(user_id).strip():
+        raise ValueError("create_synap_tools requires a non-empty user_id")
+
+    @tool
+    def search_memory(query: str) -> str:
+        """Search the user's long-term memory for relevant context.
+
+        Args:
+            query: What to look up in the user's memory.
+        """
+        try:
+            response = run_async(
+                sdk.fetch(
+                    user_id=user_id,
+                    customer_id=customer_id or None,
+                    search_query=[query],
+                    include_conversation_context=False,
+                )
+            )
+        except Exception as exc:  # noqa: BLE001 — read-side graceful degrade
+            logger.error(
+                "create_synap_tools.search_memory failed user_id=%s error=%s",
+                user_id,
+                exc,
+                exc_info=True,
+            )
+            return "No relevant memories found."
+        return (
+            getattr(response, "formatted_context", None)
+            or "No relevant memories found."
+        )
+
+    @tool
+    def store_memory(content: str) -> str:
+        """Store a fact or note in the user's long-term memory for future recall.
+
+        Args:
+            content: The information to remember.
+        """
+        with wrap_sdk_errors("smolagents.store_memory", logger, user_id=user_id):
+            result = run_async(
+                sdk.memories.create(
+                    document=content,
+                    user_id=user_id,
+                    customer_id=customer_id or None,
+                )
+            )
+        return (
+            f"Memory stored (ingestion_id: "
+            f"{getattr(result, 'ingestion_id', 'unknown')})"
+        )
+
+    return [search_memory, store_memory]

--- a/packages/integrations/synap-smolagents/tests/conftest.py
+++ b/packages/integrations/synap-smolagents/tests/conftest.py
@@ -1,0 +1,30 @@
+"""Pytest conftest for synap-smolagents tests.
+
+Re-exports shared fixtures from the canonical harness so tests can request
+``mock_sdk`` and ``failing_sdk`` without local duplication — same pattern as
+synap-agno.
+"""
+
+import os
+import sys
+
+sys.path.insert(
+    0,
+    os.path.join(os.path.dirname(__file__), "../../../synap/sdk/python"),
+)
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(
+    0,
+    os.path.join(os.path.dirname(__file__), "../../synap-integrations-common"),
+)
+
+from synap_integrations_common.testing import (  # noqa: F401, E402
+    mock_sdk,
+    failing_sdk,
+    make_fact,
+    make_preference,
+    make_episode,
+    make_emotion,
+    make_temporal_event,
+    make_unified_response,
+)

--- a/packages/integrations/synap-smolagents/tests/test_callbacks.py
+++ b/packages/integrations/synap-smolagents/tests/test_callbacks.py
@@ -1,0 +1,98 @@
+"""Tests for create_synap_recorder — Smolagents step-callback turn recorder."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from synap_smolagents import create_synap_recorder
+from synap_smolagents.callbacks import _as_text
+
+
+def step(model_output, step_number=1, error=None):
+    return SimpleNamespace(
+        model_output=model_output, step_number=step_number, error=error
+    )
+
+
+# ── validation ───────────────────────────────────────────────────────────────
+
+
+def test_requires_sdk():
+    with pytest.raises(ValueError):
+        create_synap_recorder(None, "alice", "conv")
+
+
+def test_requires_user_id(mock_sdk):
+    with pytest.raises(ValueError):
+        create_synap_recorder(mock_sdk, "", "conv")
+
+
+def test_requires_conversation_id(mock_sdk):
+    with pytest.raises(ValueError):
+        create_synap_recorder(mock_sdk, "alice", "")
+
+
+# ── recording ────────────────────────────────────────────────────────────────
+
+
+def test_records_action_step_with_per_step_doc_id(mock_sdk):
+    recorder = create_synap_recorder(mock_sdk, "alice", "conv1", customer_id="acme")
+    recorder(step("agent did a thing", step_number=2), agent=None)
+    mock_sdk.memories.create.assert_called_once()
+    kwargs = mock_sdk.memories.create.call_args.kwargs
+    assert kwargs["document"] == "agent did a thing"
+    assert kwargs["document_id"] == "smolagents-conv1-2"
+    assert kwargs["document_type"] == "ai-chat-conversation"
+    assert kwargs["user_id"] == "alice"
+    assert kwargs["customer_id"] == "acme"
+    assert kwargs["metadata"]["step"] == 2
+
+
+def test_per_step_ids_differ_across_steps(mock_sdk):
+    recorder = create_synap_recorder(mock_sdk, "alice", "conv1")
+    recorder(step("s1", step_number=1))
+    recorder(step("s2", step_number=2))
+    ids = [c.kwargs["document_id"] for c in mock_sdk.memories.create.call_args_list]
+    assert ids == ["smolagents-conv1-1", "smolagents-conv1-2"]
+
+
+def test_skips_error_steps(mock_sdk):
+    recorder = create_synap_recorder(mock_sdk, "alice", "conv1")
+    recorder(step("output", error=ValueError("boom")))
+    mock_sdk.memories.create.assert_not_called()
+
+
+def test_skips_empty_output(mock_sdk):
+    recorder = create_synap_recorder(mock_sdk, "alice", "conv1")
+    recorder(step(""))
+    recorder(step(None))
+    recorder(step("   "))
+    mock_sdk.memories.create.assert_not_called()
+
+
+def test_coerces_list_model_output(mock_sdk):
+    recorder = create_synap_recorder(mock_sdk, "alice", "conv1")
+    recorder(step([{"type": "text", "text": "hello"}, {"text": "world"}]))
+    assert mock_sdk.memories.create.call_args.kwargs["document"] == "hello\nworld"
+
+
+def test_failure_is_logged_not_raised(failing_sdk):
+    recorder = create_synap_recorder(failing_sdk, "alice", "conv1")
+    # must NOT raise — a raising callback would abort the agent run
+    recorder(step("something"))
+
+
+# ── field-name guard against upstream renames ────────────────────────────────
+
+
+def test_actionstep_has_expected_fields():
+    from smolagents.memory import ActionStep
+
+    fields = set(ActionStep.__dataclass_fields__)
+    assert {"model_output", "error", "step_number"} <= fields
+
+
+def test_as_text_helper():
+    assert _as_text(None) == ""
+    assert _as_text("hi") == "hi"
+    assert _as_text([{"text": "a"}, "b"]) == "a\nb"

--- a/packages/integrations/synap-smolagents/tests/test_short_term.py
+++ b/packages/integrations/synap-smolagents/tests/test_short_term.py
@@ -1,0 +1,94 @@
+"""Tests for synap_st_instructions — short-term context for Smolagents instructions."""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from synap_smolagents import synap_st_instructions
+from synap_integrations_common import SynapIntegrationError
+
+
+def _unavailable(mock_sdk):
+    resp = MagicMock()
+    resp.available = False
+    resp.formatted_context = ""
+    mock_sdk.conversation.context.get_context_for_prompt = AsyncMock(return_value=resp)
+    return mock_sdk
+
+
+# ── validation ───────────────────────────────────────────────────────────────
+
+
+def test_requires_sdk():
+    with pytest.raises(ValueError):
+        synap_st_instructions(None, "conv")
+
+
+def test_requires_conversation_id(mock_sdk):
+    with pytest.raises(ValueError):
+        synap_st_instructions(mock_sdk, "")
+
+
+def test_rejects_bad_style(mock_sdk):
+    with pytest.raises(ValueError):
+        synap_st_instructions(mock_sdk, "conv", style="haiku")
+
+
+def test_rejects_bad_on_error(mock_sdk):
+    with pytest.raises(ValueError):
+        synap_st_instructions(mock_sdk, "conv", on_error="explode")
+
+
+# ── composition ──────────────────────────────────────────────────────────────
+
+
+def test_prepends_context_above_instructions(mock_sdk):
+    out = synap_st_instructions(
+        mock_sdk, "conv", instructions="You are a helpful assistant."
+    )
+    assert "Recent conversation summary" in out
+    assert "You are a helpful assistant." in out
+    assert out.index("Recent conversation summary") < out.index("You are a helpful assistant.")
+    assert "<synap_short_term_context>" in out
+
+
+def test_tags_dropped_when_preamble_none(mock_sdk):
+    out = synap_st_instructions(
+        mock_sdk, "conv", instructions="BASE",
+        preamble_open=None, preamble_close=None,
+    )
+    assert "<synap_short_term_context>" not in out
+    assert "Recent conversation summary" in out
+    assert "BASE" in out
+
+
+def test_style_flows_to_sdk(mock_sdk):
+    synap_st_instructions(mock_sdk, "conv", style="structured")
+    assert (
+        mock_sdk.conversation.context.get_context_for_prompt.call_args.kwargs["style"]
+        == "structured"
+    )
+
+
+# ── empty / unavailable ──────────────────────────────────────────────────────
+
+
+def test_unavailable_returns_bare_instructions(mock_sdk):
+    sdk = _unavailable(mock_sdk)
+    assert synap_st_instructions(sdk, "conv", instructions="BASE") == "BASE"
+
+
+def test_unavailable_with_no_instructions_returns_empty(mock_sdk):
+    sdk = _unavailable(mock_sdk)
+    assert synap_st_instructions(sdk, "conv") == ""
+
+
+# ── error handling ───────────────────────────────────────────────────────────
+
+
+def test_fallback_swallows_sdk_failure(failing_sdk):
+    assert synap_st_instructions(failing_sdk, "conv", instructions="BASE") == "BASE"
+
+
+def test_raise_propagates_sdk_failure(failing_sdk):
+    with pytest.raises(SynapIntegrationError):
+        synap_st_instructions(failing_sdk, "conv", instructions="BASE", on_error="raise")

--- a/packages/integrations/synap-smolagents/tests/test_tools.py
+++ b/packages/integrations/synap-smolagents/tests/test_tools.py
@@ -1,0 +1,66 @@
+"""Tests for create_synap_tools — Smolagents memory tools."""
+
+import pytest
+
+from synap_smolagents import create_synap_tools
+from synap_integrations_common import SynapIntegrationError
+
+
+def _by_name(tools):
+    return {t.name: t for t in tools}
+
+
+def test_returns_two_named_tools(mock_sdk):
+    tools = create_synap_tools(mock_sdk, "alice")
+    assert len(tools) == 2
+    assert set(_by_name(tools)) == {"search_memory", "store_memory"}
+    assert all(callable(t) for t in tools)
+
+
+def test_search_tool_schema(mock_sdk):
+    search = _by_name(create_synap_tools(mock_sdk, "alice"))["search_memory"]
+    assert search.inputs["query"]["type"] == "string"
+    assert search.output_type == "string"
+
+
+def test_requires_sdk():
+    with pytest.raises(ValueError):
+        create_synap_tools(None, "alice")
+
+
+def test_requires_user_id(mock_sdk):
+    with pytest.raises(ValueError):
+        create_synap_tools(mock_sdk, "")
+
+
+def test_search_memory_returns_context(mock_sdk):
+    search = _by_name(create_synap_tools(mock_sdk, "alice"))["search_memory"]
+    out = search("what plan am I on")
+    assert "User Context" in out
+    assert mock_sdk.fetch.call_args.kwargs["search_query"] == ["what plan am I on"]
+
+
+def test_search_memory_degrades_on_failure(failing_sdk):
+    search = _by_name(create_synap_tools(failing_sdk, "alice"))["search_memory"]
+    assert search("q") == "No relevant memories found."
+
+
+def test_store_memory_returns_ingestion_id(mock_sdk):
+    store = _by_name(create_synap_tools(mock_sdk, "alice"))["store_memory"]
+    out = store("remember I like tea")
+    assert "ing-001" in out
+    assert mock_sdk.memories.create.call_args.kwargs["document"] == "remember I like tea"
+
+
+def test_store_memory_raises_on_failure(failing_sdk):
+    store = _by_name(create_synap_tools(failing_sdk, "alice"))["store_memory"]
+    with pytest.raises(SynapIntegrationError):
+        store("boom")
+
+
+def test_customer_id_flows_through(mock_sdk):
+    tools = _by_name(create_synap_tools(mock_sdk, "alice", customer_id="acme"))
+    tools["search_memory"]("q")
+    tools["store_memory"]("c")
+    assert mock_sdk.fetch.call_args.kwargs["customer_id"] == "acme"
+    assert mock_sdk.memories.create.call_args.kwargs["customer_id"] == "acme"

--- a/packages/integrations/synap-strands-agents/README.md
+++ b/packages/integrations/synap-strands-agents/README.md
@@ -1,0 +1,115 @@
+# maximem-synap-strands-agents
+
+[Maximem Synap](https://maximem.ai) memory for [Strands Agents](https://strandsagents.com/).
+Four surfaces, each mapped onto a native Strands extension point.
+
+```bash
+pip install maximem-synap-strands-agents
+```
+
+| Surface | Class / function | Strands extension point | What it does |
+|---|---|---|---|
+| Long-term memory | `SynapMemoryStore` | `MemoryStore` → `MemoryManager` | Synap as the agent's memory backend: recall, prompt injection, server-side extraction |
+| Short-term context | `SynapShortTermHook` | `HookProvider` (`BeforeInvocationEvent`) | Injects Synap's working-memory summary before each turn |
+| Explicit tools | `create_synap_tools` | `@tool` | `search_memory` / `store_memory` for agents not using `MemoryManager` |
+| Anticipation feed | `SynapStreamHook` | `HookProvider` (message + tool-call events) | Feeds turns and tool intent onto Synap's gRPC Listen stream |
+
+All four take an already-constructed `MaximemSynapSDK` — the app owns the SDK, its
+credentials, and (for streaming) its connection lifecycle.
+
+## Long-term memory — `SynapMemoryStore`
+
+Register Synap as a Strands `MemoryStore`; `MemoryManager` then handles recall, automatic
+prompt injection, and extraction.
+
+```python
+from strands import Agent
+from strands.memory import MemoryManager
+from maximem_synap import MaximemSynapSDK
+from synap_strands_agents import SynapMemoryStore
+
+sdk = MaximemSynapSDK(api_key="sk-...")
+store = SynapMemoryStore(sdk, user_id="alice", customer_id="acme")
+
+agent = Agent(memory_manager=MemoryManager(stores=[store]))
+```
+
+`search` reads Synap's long-term layer (`sdk.fetch`) and returns structured `MemoryEntry`
+objects. Writes go through `sdk.memories.create`: `add` for single facts, and `add_messages`
+for conversation batches — the latter ingests the assembled transcript under a **stable
+`document_id`** so `MemoryManager`'s periodic extraction updates one document instead of
+duplicating. (Recorded conversation messages, by contrast, feed only short-term compaction — so
+they are deliberately *not* the write path here.)
+
+## Short-term context — `SynapShortTermHook`
+
+Strands' `system_prompt` is static, so working-memory context is injected via a hook. It folds
+Synap's short-term summary into the current turn's first user message.
+
+```python
+from synap_strands_agents import SynapShortTermHook
+
+agent = Agent(
+    system_prompt="You are a support agent.",
+    hooks=[SynapShortTermHook(sdk, conversation_id="conv_abc")],
+)
+```
+
+`conversation_id` is required and explicit. Empty context is a no-op; SDK failures are swallowed
+by default (`on_error="fallback"`), or set `on_error="raise"` for strict environments.
+
+> **Note.** Strands exposes no ephemeral per-call injection hook to user code, so the injected
+> context becomes part of the conversation the agent persists. The hook folds one context block
+> into each turn's user message (with an idempotency guard) rather than adding throwaway turns.
+
+## Explicit tools — `create_synap_tools`
+
+For agents that want direct control instead of `MemoryManager`:
+
+```python
+from synap_strands_agents import create_synap_tools
+
+agent = Agent(
+    system_prompt="You are a helpful assistant.",
+    tools=create_synap_tools(sdk, user_id="alice", customer_id="acme"),
+)
+```
+
+Adds `search_memory(query)` and `store_memory(content)`.
+
+## Anticipation feed — `SynapStreamHook`
+
+Makes the agent a participant in Synap's real-time anticipation pipeline by feeding its turns and
+tool-call intent onto the gRPC Listen stream. The **app owns the stream lifecycle**; the hook only
+feeds an already-open stream and no-ops when none is active.
+
+```python
+from synap_strands_agents import SynapStreamHook
+
+await sdk.instance.listen()                      # app opens the stream
+hook = SynapStreamHook(sdk, conversation_id="conv_abc", user_id="alice")
+agent = Agent(hooks=[hook, SynapShortTermHook(sdk, conversation_id="conv_abc")])
+# ... run the agent ...
+await sdk.instance.stop_listening()              # app closes it on shutdown
+```
+
+> **Run on one event loop.** The stream's background tasks bind to the loop `listen()` ran on;
+> construct the SDK, call `listen()`, and run the agent on that same asyncio loop. The hook feeds
+> real-time *signal* — it does not durably store memories (that's `SynapMemoryStore` / the tools).
+
+## Error policy
+
+- **Reads** (`search`, `search_memory`) degrade gracefully — log at ERROR, return empty.
+- **Writes** (`add`, `add_messages`, `store_memory`) raise `SynapIntegrationError`.
+- **Stream sends** log and never raise — they run inside Strands' event loop and must not abort a turn.
+
+## Not in scope: `SessionManager`
+
+This integration does not implement Strands' `SessionManager` / snapshot storage. That persists
+opaque conversation snapshots for replay, which is a different concern from Synap's semantic
+memory. Use `FileSessionManager` / `S3SessionManager` for durable sessions *and* a
+`SynapMemoryStore` for memory — they compose.
+
+## License
+
+Apache-2.0

--- a/packages/integrations/synap-strands-agents/pyproject.toml
+++ b/packages/integrations/synap-strands-agents/pyproject.toml
@@ -1,0 +1,35 @@
+[build-system]
+requires = ["setuptools>=61.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "maximem-synap-strands-agents"
+version = "0.1.0"
+description = "Synap memory integration for Strands Agents — long-term memory, short-term context, and real-time anticipation"
+readme = "README.md"
+requires-python = ">=3.11"
+license = "Apache-2.0"
+authors = [
+    {name = "Synap Team"}
+]
+keywords = ["synap", "memory", "strands", "strands-agents", "ai", "agents"]
+
+dependencies = [
+    "maximem-synap>=0.2.0",
+    "maximem-synap-integrations-common>=0.1.0",
+    "strands-agents>=1.48",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.0",
+    "pytest-asyncio>=0.21",
+]
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["synap_strands_agents*"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+asyncio_mode = "auto"

--- a/packages/integrations/synap-strands-agents/synap_strands_agents/__init__.py
+++ b/packages/integrations/synap-strands-agents/synap_strands_agents/__init__.py
@@ -1,0 +1,45 @@
+"""Synap memory integration for Strands Agents.
+
+Four surfaces, each mapped onto a native Strands extension point:
+
+- :class:`SynapMemoryStore` — implements Strands' ``MemoryStore`` protocol so
+  ``MemoryManager`` uses Synap as the agent's long-term memory backend
+  (recall + automatic prompt injection + server-side extraction).
+- :class:`SynapShortTermHook` — a ``HookProvider`` that injects Synap
+  short-term / working-memory context before each invocation.
+- :func:`create_synap_tools` — explicit ``search_memory`` / ``store_memory``
+  ``@tool`` functions for agents that don't adopt ``MemoryManager``.
+- :class:`SynapStreamHook` — a ``HookProvider`` that feeds the agent's turns
+  and tool-call intent onto Synap's gRPC Listen / anticipation stream.
+
+Typical wiring::
+
+    from strands import Agent
+    from strands.memory import MemoryManager
+    from maximem_synap import MaximemSynapSDK
+    from synap_strands_agents import SynapMemoryStore, SynapShortTermHook
+
+    sdk = MaximemSynapSDK(api_key="sk-...")
+    store = SynapMemoryStore(sdk, user_id="alice", customer_id="acme")
+
+    agent = Agent(
+        system_prompt="You are a helpful assistant.",
+        memory_manager=MemoryManager(stores=[store]),
+        hooks=[SynapShortTermHook(sdk, conversation_id="conv_abc")],
+    )
+
+See each surface's docstring for its error policy and the ``stream.py`` module
+for the gRPC Listen participation contract (the app owns ``sdk.instance.listen()``).
+"""
+
+from synap_strands_agents.short_term import SynapShortTermHook
+from synap_strands_agents.store import SynapMemoryStore
+from synap_strands_agents.stream import SynapStreamHook
+from synap_strands_agents.tools import create_synap_tools
+
+__all__ = [
+    "SynapMemoryStore",
+    "SynapShortTermHook",
+    "SynapStreamHook",
+    "create_synap_tools",
+]

--- a/packages/integrations/synap-strands-agents/synap_strands_agents/_util.py
+++ b/packages/integrations/synap-strands-agents/synap_strands_agents/_util.py
@@ -1,0 +1,27 @@
+"""Internal helpers shared across surfaces. Not part of the public API."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def message_text(message: Any) -> str:
+    """Join the text blocks of a Strands ``Message`` into one string.
+
+    A Strands ``Message`` is ``{"role": str, "content": list[ContentBlock]}``.
+    Only ``{"text": ...}`` blocks contribute; ``toolUse`` / ``toolResult`` /
+    image blocks yield no text. Callers treat an empty result as "skip this
+    message" (e.g. tool-result turns carry no natural-language text).
+    """
+    if not isinstance(message, dict):
+        return ""
+    content = message.get("content")
+    if not content:
+        return ""
+    parts = []
+    for block in content:
+        if isinstance(block, dict):
+            text = block.get("text")
+            if isinstance(text, str) and text:
+                parts.append(text)
+    return "\n".join(parts).strip()

--- a/packages/integrations/synap-strands-agents/synap_strands_agents/short_term.py
+++ b/packages/integrations/synap-strands-agents/synap_strands_agents/short_term.py
@@ -1,0 +1,188 @@
+"""Synap short-term context injection for Strands Agents.
+
+Strands' ``system_prompt`` is a static string, so short-term / working-memory
+context is injected via a :class:`~strands.hooks.HookProvider` on
+``BeforeInvocationEvent`` — the one before-event whose ``.messages`` list is
+writable (``BeforeModelCallEvent`` only permits cancelling).
+
+**On persistence.** Strands has no ephemeral per-call injection hook for user
+code (only ``MemoryManager`` uses ``strands.injection`` internally). Whatever
+you put in ``event.messages`` is appended to the agent's durable history. To
+avoid accumulating throwaway context turns, this hook **folds the short-term
+block into the current turn's first user message** rather than adding a
+separate turn — each user turn simply carries its contemporaneous context, and
+there is an idempotency guard so a re-entered invocation never double-folds.
+Folding (vs. a standalone ``user`` turn) also avoids consecutive same-role
+messages, which some model providers reject.
+
+Wraps ``sdk.conversation.context.get_context_for_prompt`` (cache-first behind
+``SYNAP_SDK_ST_AUTHORITATIVE``). Quality contract, identical to the LangGraph /
+Agno adapters:
+
+- ``conversation_id`` required + explicit at construction.
+- SDK failures never crash the agent by default (``on_error="fallback"``).
+- Empty short-term context is a no-op — never mutates the user's input.
+- ``on_error="raise"`` available for strict environments.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, List, Literal, Optional
+
+from strands.hooks import BeforeInvocationEvent, HookProvider, HookRegistry
+
+from maximem_synap import MaximemSynapSDK
+from synap_integrations_common import SynapIntegrationError, wrap_sdk_errors_async
+
+logger = logging.getLogger(__name__)
+
+_SUPPORTED_STYLES = ("structured", "narrative", "bullet_points")
+_DEFAULT_OPEN = "<synap_short_term_context>"
+_DEFAULT_CLOSE = "</synap_short_term_context>"
+
+_OnError = Literal["fallback", "raise"]
+
+
+def _validate_args(
+    sdk: Optional[MaximemSynapSDK],
+    conversation_id: str,
+    style: str,
+    on_error: str,
+    site: str,
+) -> None:
+    if sdk is None:
+        raise ValueError(f"{site} requires a non-None sdk")
+    if not conversation_id or not str(conversation_id).strip():
+        raise ValueError(f"{site} requires a non-empty conversation_id")
+    if style not in _SUPPORTED_STYLES:
+        raise ValueError(
+            f"{site}: unsupported style={style!r}; "
+            f"expected one of {_SUPPORTED_STYLES}"
+        )
+    if on_error not in ("fallback", "raise"):
+        raise ValueError(
+            f"{site}: on_error must be 'fallback' or 'raise', got {on_error!r}"
+        )
+
+
+async def _fetch_st_block(
+    sdk: MaximemSynapSDK,
+    conversation_id: str,
+    style: str,
+    on_error: _OnError,
+    site: str,
+) -> str:
+    try:
+        async with wrap_sdk_errors_async(
+            site,
+            logger,
+            conversation_id=conversation_id,
+            style=style,
+        ):
+            response = await sdk.conversation.context.get_context_for_prompt(
+                conversation_id=conversation_id,
+                style=style,
+            )
+    except SynapIntegrationError:
+        if on_error == "raise":
+            raise
+        return ""
+    if not getattr(response, "available", False):
+        return ""
+    formatted = getattr(response, "formatted_context", None)
+    return (formatted or "").strip()
+
+
+class SynapShortTermHook(HookProvider):
+    """Inject Synap short-term context before each Strands invocation.
+
+    Args:
+        sdk: Initialised :class:`MaximemSynapSDK`.
+        conversation_id: Synap conversation ID. **Required and explicit** —
+            never inferred from a Strands session id.
+        style: One of ``"structured" | "narrative" | "bullet_points"``.
+        preamble_open / preamble_close: Tags wrapping the injected block; pass
+            ``None`` for both to drop them (which also disables the idempotency
+            guard, so keep the defaults unless you have a reason not to).
+        on_error: ``"fallback"`` (default) swallows SDK failures and leaves the
+            input untouched; ``"raise"`` propagates :class:`SynapIntegrationError`.
+
+    Example::
+
+        from strands import Agent
+        from maximem_synap import MaximemSynapSDK
+        from synap_strands_agents import SynapShortTermHook
+
+        sdk = MaximemSynapSDK(api_key="sk-...")
+        agent = Agent(
+            system_prompt="You are a support agent.",
+            hooks=[SynapShortTermHook(sdk, conversation_id="conv_abc")],
+        )
+    """
+
+    def __init__(
+        self,
+        sdk: MaximemSynapSDK,
+        conversation_id: str,
+        *,
+        style: str = "narrative",
+        preamble_open: Optional[str] = _DEFAULT_OPEN,
+        preamble_close: Optional[str] = _DEFAULT_CLOSE,
+        on_error: _OnError = "fallback",
+    ) -> None:
+        _validate_args(sdk, conversation_id, style, on_error, "SynapShortTermHook")
+        self._sdk = sdk
+        self._conversation_id = conversation_id
+        self._style = style
+        self._preamble_open = preamble_open
+        self._preamble_close = preamble_close
+        self._on_error = on_error
+
+    def register_hooks(self, registry: HookRegistry, **kwargs: Any) -> None:
+        registry.add_callback(BeforeInvocationEvent, self._inject)
+
+    async def _inject(self, event: BeforeInvocationEvent) -> None:
+        st_block = await _fetch_st_block(
+            self._sdk,
+            self._conversation_id,
+            self._style,
+            self._on_error,
+            "synap_strands_agents.SynapShortTermHook",
+        )
+        if not st_block:
+            return  # no short-term context -> never touch the input
+        messages = event.messages
+        if not messages:
+            return  # nothing to fold into (e.g. the structured_output path)
+        self._fold_into_first_user(messages, st_block)
+
+    def _wrap(self, st_block: str) -> str:
+        if self._preamble_open and self._preamble_close:
+            return f"{self._preamble_open}\n{st_block}\n{self._preamble_close}"
+        return st_block
+
+    def _already_injected(self, content: List[Any]) -> bool:
+        if not self._preamble_open:
+            return False
+        return any(
+            isinstance(b, dict)
+            and isinstance(b.get("text"), str)
+            and b["text"].lstrip().startswith(self._preamble_open)
+            for b in content
+        )
+
+    def _fold_into_first_user(self, messages: List[Any], st_block: str) -> None:
+        for message in messages:
+            if not isinstance(message, dict) or message.get("role") != "user":
+                continue
+            content = message.get("content")
+            if not isinstance(content, list):
+                continue
+            if self._already_injected(content):
+                return  # re-entered invocation — don't double-fold
+            content.insert(0, {"text": self._wrap(st_block)})
+            return
+
+
+__all__ = ["SynapShortTermHook"]

--- a/packages/integrations/synap-strands-agents/synap_strands_agents/store.py
+++ b/packages/integrations/synap-strands-agents/synap_strands_agents/store.py
@@ -1,0 +1,198 @@
+"""Synap long-term memory backend for Strands Agents.
+
+Implements Strands' ``MemoryStore`` protocol so ``MemoryManager`` uses Synap as
+the agent's long-term memory: recall (a ``search_memory`` tool), automatic
+prompt injection, and server-side extraction. ``MemoryStore`` is a
+``typing.Protocol`` — this class satisfies it structurally (five config
+attributes + ``search`` + optional write sinks), it does not subclass an ABC.
+
+Error policy:
+- ``search`` (read) degrades gracefully: log at ERROR, return ``[]`` — a Synap
+  blip must not crash recall.
+- ``add`` / ``add_messages`` (writes) surface :class:`SynapIntegrationError`.
+
+Why ``add_messages`` ingests through ``memories.create`` rather than
+``conversation.record_messages_batch``: recorded conversation messages feed
+**compaction / short-term context**, not the long-term extraction layer that
+``search``/``fetch`` reads (see ``sdk/ingestion.mdx``). Ingesting the assembled
+transcript via ``memories.create`` runs Synap's extraction pipeline server-side
+(no client model call) and lands memories on the same layer ``search`` queries.
+A **stable ``document_id``** makes ``MemoryManager``'s repeated, growing-
+transcript extraction submissions *update* one document instead of accumulating
+duplicates.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from typing import Any, List, Optional
+
+from strands.memory import MemoryEntry
+
+from maximem_synap import MaximemSynapSDK
+from synap_integrations_common import wrap_sdk_errors_async
+
+from synap_strands_agents._util import message_text
+
+logger = logging.getLogger(__name__)
+
+# Each Synap context category -> (response attr, synap_type tag, content attr).
+_CATEGORIES = (
+    ("facts", "fact", "content"),
+    ("preferences", "preference", "content"),
+    ("episodes", "episode", "summary"),
+    ("emotions", "emotion", "context"),
+    ("temporal_events", "temporal_event", "content"),
+)
+
+
+class SynapMemoryStore:
+    """Synap-backed implementation of the Strands ``MemoryStore`` protocol.
+
+    Args:
+        sdk: Initialised :class:`MaximemSynapSDK`.
+        user_id: External user id these memories are about. **Required.**
+        customer_id: Optional customer/org scope. Empty means customer-less.
+        conversation_id: Optional Synap conversation id; also seeds the stable
+            ``document_id`` used by ``add_messages`` so repeated ingests of a
+            growing transcript update one document rather than duplicating.
+        mode: Synap fetch mode — ``"accurate"`` (default) or ``"fast"``.
+        max_search_results: Default cap on ``search`` results.
+
+    Example::
+
+        from strands import Agent
+        from strands.memory import MemoryManager
+        from maximem_synap import MaximemSynapSDK
+        from synap_strands_agents import SynapMemoryStore
+
+        sdk = MaximemSynapSDK(api_key="sk-...")
+        store = SynapMemoryStore(sdk, user_id="alice", customer_id="acme")
+        agent = Agent(memory_manager=MemoryManager(stores=[store]))
+    """
+
+    def __init__(
+        self,
+        sdk: MaximemSynapSDK,
+        user_id: str,
+        *,
+        customer_id: str = "",
+        conversation_id: Optional[str] = None,
+        mode: str = "accurate",
+        max_search_results: int = 5,
+    ) -> None:
+        if sdk is None:
+            raise ValueError("SynapMemoryStore requires a non-None sdk")
+        if not user_id:
+            raise ValueError("SynapMemoryStore requires a non-empty user_id")
+        self._sdk = sdk
+        self._user_id = user_id
+        self._customer_id = customer_id
+        self._conversation_id = conversation_id
+        self._mode = mode
+        # Stable document id so add_messages re-ingests update one document.
+        self._document_id = (
+            f"strands-{conversation_id}"
+            if conversation_id
+            else f"strands-{uuid.uuid4().hex}"
+        )
+        # ── MemoryStore protocol config fields (exposed as attributes) ──
+        self.name = "synap"
+        self.description = "Maximem Synap long-term memory"
+        self.max_search_results = max_search_results
+        self.writable = True
+        self.extraction = True
+
+    # ── read ─────────────────────────────────────────────────────────────────
+
+    async def search(self, query: str, options: Any = None) -> List[MemoryEntry]:
+        """Return Synap memories matching ``query`` (READ — degrades to ``[]``)."""
+        limit = (options or {}).get("max_search_results") or self.max_search_results
+        try:
+            response = await self._sdk.fetch(
+                conversation_id=self._conversation_id,
+                user_id=self._user_id,
+                customer_id=self._customer_id or None,
+                search_query=[query],
+                mode=self._mode,
+                max_results=limit,
+                include_conversation_context=False,
+            )
+        except Exception as exc:  # noqa: BLE001 — read-side graceful degrade
+            logger.error(
+                "SynapMemoryStore.search failed user_id=%s error=%s",
+                self._user_id, exc, exc_info=True,
+            )
+            return []
+        return self._to_entries(response, limit)
+
+    def _to_entries(self, response: Any, limit: int) -> List[MemoryEntry]:
+        entries: List[MemoryEntry] = []
+        for attr, synap_type, content_attr in _CATEGORIES:
+            for item in getattr(response, attr, None) or []:
+                content = getattr(item, content_attr, None) or getattr(
+                    item, "content", None
+                )
+                if not content:
+                    continue
+                entries.append(
+                    MemoryEntry(
+                        content=str(content),
+                        metadata={
+                            "synap_type": synap_type,
+                            "id": str(getattr(item, "id", "") or ""),
+                        },
+                    )
+                )
+                if len(entries) >= limit:
+                    return entries
+        return entries
+
+    # ── writes ─────────────────────────────────────────────────────────────────
+
+    async def add(self, content: str, metadata: Any = None) -> None:
+        """Ingest a single piece of content (WRITE — raises on failure)."""
+        async with wrap_sdk_errors_async(
+            "strands.store.add", logger, user_id=self._user_id,
+        ):
+            await self._sdk.memories.create(
+                document=content,
+                user_id=self._user_id,
+                customer_id=self._customer_id or None,
+                metadata=dict(metadata) if metadata else None,
+            )
+
+    async def add_messages(self, messages: Any, context: Any = None) -> None:
+        """Ingest a conversation batch for server-side extraction (WRITE)."""
+        transcript = self._render_transcript(messages)
+        if not transcript:
+            return  # nothing extractable (e.g. all tool-result turns)
+        async with wrap_sdk_errors_async(
+            "strands.store.add_messages", logger, user_id=self._user_id,
+        ):
+            await self._sdk.memories.create(
+                document=transcript,
+                user_id=self._user_id,
+                customer_id=self._customer_id or None,
+                document_type="ai-chat-conversation",
+                document_id=self._document_id,
+            )
+
+    @staticmethod
+    def _render_transcript(messages: Any) -> str:
+        lines: List[str] = []
+        for message in messages or []:
+            if not isinstance(message, dict):
+                continue
+            role = message.get("role")
+            if role not in ("user", "assistant"):
+                continue
+            text = message_text(message)
+            if not text:
+                continue
+            lines.append(f"{role}: {text}")
+        return "\n".join(lines)
+
+
+__all__ = ["SynapMemoryStore"]

--- a/packages/integrations/synap-strands-agents/synap_strands_agents/stream.py
+++ b/packages/integrations/synap-strands-agents/synap_strands_agents/stream.py
@@ -1,0 +1,139 @@
+"""Synap gRPC Listen-stream participation for Strands Agents.
+
+Makes a Strands agent a first-class participant in Synap's real-time
+anticipation pipeline. A :class:`~strands.hooks.HookProvider` maps Strands
+lifecycle events onto the SDK's outbound stream sends so the Synap Anticipation
+Agent sees the agent's turns and planned tool calls *as they happen* and can
+pre-fetch context before the agent asks.
+
+The **read** side needs no help — when the stream is live the SDK's own
+``fetch()`` already emits ``context_fetch`` / ``context_used`` /
+``context_assembled`` events. This hook only feeds the **activity** the SDK
+can't infer: conversation turns and tool-call intent.
+
+Lifecycle is the app's job, not the hook's:
+
+    await sdk.instance.listen()                     # app opens the stream
+    hook = SynapStreamHook(sdk, conversation_id="c1", user_id="alice")
+    agent = Agent(hooks=[hook])
+    # ... run the agent on the SAME asyncio event loop ...
+    await sdk.instance.stop_listening()             # app closes it on shutdown
+
+Design rules (these differ from the other surfaces):
+- **Gate every send on ``sdk.instance.is_listening``**; no-op silently when the
+  app never called ``listen()`` — never raise ``ListeningNotActiveError``.
+- **Log, never raise.** These run inside Strands' event loop; a raising hook can
+  abort the agent turn. This mirrors the SDK's own fire-and-forget stream sends.
+- This feeds *signal*, it does not durably ingest. Long-term memory still comes
+  only from :class:`~synap_strands_agents.store.SynapMemoryStore` /
+  :func:`~synap_strands_agents.tools.create_synap_tools`.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional
+
+from strands.hooks import (
+    BeforeToolCallEvent,
+    HookProvider,
+    HookRegistry,
+    MessageAddedEvent,
+)
+
+from maximem_synap import MaximemSynapSDK
+
+from synap_strands_agents._util import message_text
+
+logger = logging.getLogger(__name__)
+
+
+class SynapStreamHook(HookProvider):
+    """Feed a Strands agent's turns and tool intent onto Synap's Listen stream.
+
+    Args:
+        sdk: Initialised :class:`MaximemSynapSDK`. The app owns its
+            ``listen()`` / ``stop_listening()`` lifecycle; this hook only feeds
+            an already-open stream and no-ops when none is active.
+        conversation_id: Synap conversation id for the emitted events. **Required.**
+        user_id: External user id for the conversation. **Required.**
+        customer_id: Optional customer/org scope.
+        session_id: Optional session identifier attached to emitted events.
+    """
+
+    def __init__(
+        self,
+        sdk: MaximemSynapSDK,
+        conversation_id: str,
+        user_id: str,
+        *,
+        customer_id: str = "",
+        session_id: str = "",
+    ) -> None:
+        if sdk is None:
+            raise ValueError("SynapStreamHook requires a non-None sdk")
+        if not conversation_id or not str(conversation_id).strip():
+            raise ValueError("SynapStreamHook requires a non-empty conversation_id")
+        if not user_id:
+            raise ValueError("SynapStreamHook requires a non-empty user_id")
+        self._sdk = sdk
+        self._conversation_id = conversation_id
+        self._user_id = user_id
+        self._customer_id = customer_id
+        self._session_id = session_id
+
+    def register_hooks(self, registry: HookRegistry, **kwargs: Any) -> None:
+        registry.add_callback(MessageAddedEvent, self._on_message)
+        registry.add_callback(BeforeToolCallEvent, self._on_tool_call)
+
+    async def _on_message(self, event: MessageAddedEvent) -> None:
+        try:
+            if not self._sdk.instance.is_listening:
+                return
+            message = event.message
+            text = message_text(message)
+            if not text:
+                return  # tool-result / tool-use-only turns carry no text
+            role = message.get("role", "user") if isinstance(message, dict) else "user"
+            event_type = "assistant_message" if role == "assistant" else "user_message"
+            await self._sdk.instance.send_message(
+                content=text,
+                role=role,
+                event_type=event_type,
+                conversation_id=self._conversation_id,
+                user_id=self._user_id,
+                customer_id=self._customer_id or None,
+                session_id=self._session_id or None,
+            )
+        except Exception as exc:  # noqa: BLE001 — stream feed must never abort the turn
+            logger.warning(
+                "SynapStreamHook: message feed failed: %s", exc, exc_info=True
+            )
+
+    async def _on_tool_call(self, event: BeforeToolCallEvent) -> None:
+        try:
+            if not self._sdk.instance.is_listening:
+                return
+            tool_use = event.tool_use or {}
+            tool_name = tool_use.get("name", "") if isinstance(tool_use, dict) else ""
+            if not tool_name:
+                return
+            tool_args = tool_use.get("input") if isinstance(tool_use, dict) else None
+            await self._sdk.instance.send_message(
+                content=tool_name,
+                role="assistant",
+                event_type="tool_call",
+                tool_name=tool_name,
+                tool_args=tool_args,
+                conversation_id=self._conversation_id,
+                user_id=self._user_id,
+                customer_id=self._customer_id or None,
+                session_id=self._session_id or None,
+            )
+        except Exception as exc:  # noqa: BLE001 — stream feed must never abort the turn
+            logger.warning(
+                "SynapStreamHook: tool-call feed failed: %s", exc, exc_info=True
+            )
+
+
+__all__ = ["SynapStreamHook"]

--- a/packages/integrations/synap-strands-agents/synap_strands_agents/tools.py
+++ b/packages/integrations/synap-strands-agents/synap_strands_agents/tools.py
@@ -1,0 +1,105 @@
+"""Synap tools for Strands agents.
+
+Provides ``search_memory`` and ``store_memory`` as Strands ``@tool`` functions
+for agents that want explicit memory operations without adopting the full
+``MemoryManager`` wiring (see :mod:`synap_strands_agents.store` for that).
+
+SDK failures are wrapped in :class:`SynapIntegrationError` so the agent sees a
+consistent error type rather than a leaked raw SDK exception.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from strands import tool
+
+from maximem_synap import MaximemSynapSDK
+from synap_integrations_common import wrap_sdk_errors_async
+
+logger = logging.getLogger(__name__)
+
+
+def create_synap_tools(
+    sdk: MaximemSynapSDK,
+    user_id: str,
+    customer_id: str = "",
+    conversation_id: Optional[str] = None,
+) -> list:
+    """Create Strands tools for Synap memory operations.
+
+    Returns ``[search_memory, store_memory]`` as Strands ``@tool`` functions
+    ready for ``Agent(tools=...)``. The decorated functions are also directly
+    awaitable, which is what the tests exercise.
+
+    Args:
+        sdk: Initialised :class:`MaximemSynapSDK`.
+        user_id: External user id these operations act on. **Required.**
+        customer_id: Optional customer/org scope. Empty means customer-less.
+        conversation_id: Optional Synap conversation id threaded into ``fetch``.
+
+    Example::
+
+        from strands import Agent
+        from maximem_synap import MaximemSynapSDK
+        from synap_strands_agents import create_synap_tools
+
+        sdk = MaximemSynapSDK(api_key="sk-...")
+        agent = Agent(
+            system_prompt="You are a helpful assistant.",
+            tools=create_synap_tools(sdk, user_id="alice", customer_id="acme"),
+        )
+    """
+    if sdk is None:
+        raise ValueError("create_synap_tools requires a non-None sdk")
+    if not user_id:
+        raise ValueError("create_synap_tools requires a non-empty user_id")
+
+    @tool
+    async def search_memory(query: str) -> str:
+        """Search the user's memory for relevant context.
+
+        Args:
+            query: Natural language search query.
+
+        Returns:
+            Formatted context from memory, or a not-found message.
+        """
+        async with wrap_sdk_errors_async(
+            "strands.search_memory", logger, user_id=user_id,
+        ):
+            response = await sdk.fetch(
+                conversation_id=conversation_id,
+                user_id=user_id,
+                customer_id=customer_id or None,
+                search_query=[query],
+                mode="accurate",
+                include_conversation_context=False,
+            )
+        return response.formatted_context or "No relevant memories found."
+
+    @tool
+    async def store_memory(content: str) -> str:
+        """Store important information about the user.
+
+        Args:
+            content: Information to remember.
+
+        Returns:
+            Confirmation message with the ingestion id.
+        """
+        async with wrap_sdk_errors_async(
+            "strands.store_memory", logger, user_id=user_id,
+        ):
+            result = await sdk.memories.create(
+                document=content,
+                user_id=user_id,
+                customer_id=customer_id,
+            )
+        return f"Memory stored (ingestion_id: {result.ingestion_id})"
+
+    return [search_memory, store_memory]
+
+
+__all__ = ["create_synap_tools"]

--- a/packages/integrations/synap-strands-agents/tests/conftest.py
+++ b/packages/integrations/synap-strands-agents/tests/conftest.py
@@ -1,0 +1,30 @@
+"""Pytest conftest for synap-strands-agents tests.
+
+Re-exports shared fixtures from the canonical harness so tests can request
+``mock_sdk`` and ``failing_sdk`` without local duplication — same pattern as
+synap-agno / synap-langchain.
+"""
+
+import os
+import sys
+
+sys.path.insert(
+    0,
+    os.path.join(os.path.dirname(__file__), "../../../synap/sdk/python"),
+)
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(
+    0,
+    os.path.join(os.path.dirname(__file__), "../../synap-integrations-common"),
+)
+
+from synap_integrations_common.testing import (  # noqa: F401, E402
+    mock_sdk,
+    failing_sdk,
+    make_fact,
+    make_preference,
+    make_episode,
+    make_emotion,
+    make_temporal_event,
+    make_unified_response,
+)

--- a/packages/integrations/synap-strands-agents/tests/test_short_term.py
+++ b/packages/integrations/synap-strands-agents/tests/test_short_term.py
@@ -1,0 +1,150 @@
+"""Tests for synap_strands_agents.short_term — SynapShortTermHook.
+
+Contract:
+- folds Synap short-term context into the current turn's first user message.
+- empty / unavailable ST is a no-op (input untouched).
+- SDK failure: on_error="fallback" -> no-op; on_error="raise" -> SynapIntegrationError.
+- injection is idempotent within a re-entered invocation (no double-fold).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from strands.hooks import BeforeInvocationEvent
+
+from synap_integrations_common import SynapIntegrationError
+
+from synap_strands_agents.short_term import (
+    _DEFAULT_OPEN,
+    SynapShortTermHook,
+)
+
+
+def _event(messages):
+    return BeforeInvocationEvent(agent=MagicMock(), messages=messages)
+
+
+def _user(text):
+    return {"role": "user", "content": [{"text": text}]}
+
+
+def _first_user_text(event):
+    for m in event.messages:
+        if m.get("role") == "user":
+            return m["content"][0]["text"]
+    raise AssertionError("no user message")
+
+
+# ── construction / validation ───────────────────────────────────────────────
+
+
+def test_requires_sdk():
+    with pytest.raises(ValueError):
+        SynapShortTermHook(None, "conv_1")
+
+
+def test_requires_conversation_id(mock_sdk):
+    with pytest.raises(ValueError):
+        SynapShortTermHook(mock_sdk, "")
+
+
+def test_rejects_bad_style(mock_sdk):
+    with pytest.raises(ValueError):
+        SynapShortTermHook(mock_sdk, "conv_1", style="poem")
+
+
+def test_rejects_bad_on_error(mock_sdk):
+    with pytest.raises(ValueError):
+        SynapShortTermHook(mock_sdk, "conv_1", on_error="explode")
+
+
+def test_register_hooks_subscribes_before_invocation(mock_sdk):
+    hook = SynapShortTermHook(mock_sdk, "conv_1")
+    registry = MagicMock()
+    hook.register_hooks(registry)
+    registry.add_callback.assert_called_once()
+    args = registry.add_callback.call_args.args
+    assert args[0] is BeforeInvocationEvent
+
+
+# ── injection ────────────────────────────────────────────────────────────────
+
+
+async def test_folds_context_into_first_user_message(mock_sdk):
+    hook = SynapShortTermHook(mock_sdk, "conv_1")
+    event = _event([_user("what's my status?")])
+
+    await hook._inject(event)
+
+    text = _first_user_text(event)
+    assert text.startswith(_DEFAULT_OPEN)
+    assert "Recent conversation summary" in text
+    # original user text preserved as a separate content block
+    assert event.messages[0]["content"][1] == {"text": "what's my status?"}
+
+
+async def test_no_op_when_unavailable(mock_sdk):
+    mock_sdk.conversation.context.get_context_for_prompt.return_value = MagicMock(
+        available=False, formatted_context=""
+    )
+    hook = SynapShortTermHook(mock_sdk, "conv_1")
+    event = _event([_user("hi")])
+
+    await hook._inject(event)
+
+    assert event.messages[0]["content"] == [{"text": "hi"}]
+
+
+async def test_no_op_when_empty_context(mock_sdk):
+    mock_sdk.conversation.context.get_context_for_prompt.return_value = MagicMock(
+        available=True, formatted_context="   "
+    )
+    hook = SynapShortTermHook(mock_sdk, "conv_1")
+    event = _event([_user("hi")])
+
+    await hook._inject(event)
+
+    assert event.messages[0]["content"] == [{"text": "hi"}]
+
+
+async def test_idempotent_no_double_fold(mock_sdk):
+    hook = SynapShortTermHook(mock_sdk, "conv_1")
+    event = _event([_user("hi")])
+
+    await hook._inject(event)
+    await hook._inject(event)
+
+    texts = [b["text"] for b in event.messages[0]["content"]]
+    assert sum(t.lstrip().startswith(_DEFAULT_OPEN) for t in texts) == 1
+
+
+async def test_no_user_message_is_safe(mock_sdk):
+    hook = SynapShortTermHook(mock_sdk, "conv_1")
+    event = _event([{"role": "assistant", "content": [{"text": "prior"}]}])
+
+    await hook._inject(event)  # must not raise
+
+    assert event.messages[0]["content"] == [{"text": "prior"}]
+
+
+# ── error policy ─────────────────────────────────────────────────────────────
+
+
+async def test_fallback_swallows_sdk_failure(failing_sdk):
+    hook = SynapShortTermHook(failing_sdk, "conv_1", on_error="fallback")
+    event = _event([_user("hi")])
+
+    await hook._inject(event)  # must not raise
+
+    assert event.messages[0]["content"] == [{"text": "hi"}]
+
+
+async def test_raise_propagates_sdk_failure(failing_sdk):
+    hook = SynapShortTermHook(failing_sdk, "conv_1", on_error="raise")
+    event = _event([_user("hi")])
+
+    with pytest.raises(SynapIntegrationError):
+        await hook._inject(event)

--- a/packages/integrations/synap-strands-agents/tests/test_store.py
+++ b/packages/integrations/synap-strands-agents/tests/test_store.py
@@ -1,0 +1,167 @@
+"""Tests for synap_strands_agents.store — SynapMemoryStore.
+
+Contract:
+- satisfies the Strands MemoryStore protocol (5 config attrs + search/add/add_messages).
+- search maps Synap structured items -> MemoryEntry, honors max_search_results,
+  and degrades to [] on SDK failure.
+- add / add_messages ingest via memories.create (NOT record_messages_batch),
+  add_messages uses a stable document_id, and both raise on failure.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from strands.memory import MemoryEntry, MemoryManager
+
+from synap_integrations_common import SynapIntegrationError
+from synap_integrations_common.testing import (
+    make_episode,
+    make_fact,
+    make_preference,
+    make_unified_response,
+)
+
+from synap_strands_agents.store import SynapMemoryStore
+
+
+def _user(text):
+    return {"role": "user", "content": [{"text": text}]}
+
+
+def _assistant(text):
+    return {"role": "assistant", "content": [{"text": text}]}
+
+
+# ── construction / protocol shape ────────────────────────────────────────────
+
+
+def test_requires_sdk():
+    with pytest.raises(ValueError):
+        SynapMemoryStore(None, "alice")
+
+
+def test_requires_user_id(mock_sdk):
+    with pytest.raises(ValueError):
+        SynapMemoryStore(mock_sdk, "")
+
+
+def test_exposes_protocol_config_fields(mock_sdk):
+    store = SynapMemoryStore(mock_sdk, "alice", max_search_results=7)
+    assert store.name == "synap"
+    assert store.description
+    assert store.max_search_results == 7
+    assert store.writable is True
+    assert store.extraction is True
+
+
+def test_satisfies_memory_manager(mock_sdk):
+    store = SynapMemoryStore(mock_sdk, "alice")
+    mgr = MemoryManager(stores=[store])  # must not raise
+    assert mgr is not None
+
+
+# ── search ───────────────────────────────────────────────────────────────────
+
+
+async def test_search_maps_structured_items_to_entries(mock_sdk):
+    store = SynapMemoryStore(mock_sdk, "alice", customer_id="acme")
+    entries = await store.search("who am i")
+
+    assert all(isinstance(e, MemoryEntry) for e in entries)
+    contents = [e.content for e in entries]
+    assert "User is an engineer" in contents          # from make_fact()
+    assert "Prefers dark mode" in contents             # from make_preference()
+    types = {e.metadata["synap_type"] for e in entries}
+    assert {"fact", "preference"} <= types
+
+    kwargs = mock_sdk.fetch.await_args.kwargs
+    assert kwargs["user_id"] == "alice"
+    assert kwargs["customer_id"] == "acme"
+    assert kwargs["search_query"] == ["who am i"]
+
+
+async def test_search_covers_all_categories(mock_sdk):
+    mock_sdk.fetch.return_value = make_unified_response(
+        facts=[make_fact(content="fact one")],
+        preferences=[make_preference(content="pref one")],
+        episodes=[make_episode(summary="episode one")],
+    )
+    store = SynapMemoryStore(mock_sdk, "alice", max_search_results=10)
+    entries = await store.search("q")
+    contents = [e.content for e in entries]
+    assert "episode one" in contents  # episodes mapped via .summary
+
+
+async def test_search_honors_max_search_results(mock_sdk):
+    store = SynapMemoryStore(mock_sdk, "alice", max_search_results=5)
+    entries = await store.search("q", options={"max_search_results": 1})
+
+    assert len(entries) == 1
+    assert mock_sdk.fetch.await_args.kwargs["max_results"] == 1
+
+
+async def test_search_degrades_on_failure(failing_sdk):
+    store = SynapMemoryStore(failing_sdk, "alice")
+    assert await store.search("q") == []
+
+
+# ── add ──────────────────────────────────────────────────────────────────────
+
+
+async def test_add_ingests_via_memories_create(mock_sdk):
+    store = SynapMemoryStore(mock_sdk, "alice", customer_id="acme")
+    await store.add("User likes tea", metadata={"k": "v"})
+
+    mock_sdk.memories.create.assert_awaited_once()
+    kwargs = mock_sdk.memories.create.await_args.kwargs
+    assert kwargs["document"] == "User likes tea"
+    assert kwargs["user_id"] == "alice"
+    assert kwargs["customer_id"] == "acme"
+    assert kwargs["metadata"] == {"k": "v"}
+
+
+async def test_add_raises_on_failure(failing_sdk):
+    store = SynapMemoryStore(failing_sdk, "alice")
+    with pytest.raises(SynapIntegrationError):
+        await store.add("boom")
+
+
+# ── add_messages ─────────────────────────────────────────────────────────────
+
+
+async def test_add_messages_renders_transcript_and_ingests(mock_sdk):
+    store = SynapMemoryStore(mock_sdk, "alice", conversation_id="conv_1")
+    await store.add_messages(
+        [
+            _user("what's the weather"),
+            _assistant("sunny"),
+            {"role": "user", "content": [{"toolResult": {"x": 1}}]},  # no text
+        ]
+    )
+
+    kwargs = mock_sdk.memories.create.await_args.kwargs
+    assert kwargs["document"] == "user: what's the weather\nassistant: sunny"
+    assert kwargs["document_type"] == "ai-chat-conversation"
+    assert kwargs["document_id"] == "strands-conv_1"
+
+
+async def test_add_messages_document_id_is_stable(mock_sdk):
+    store = SynapMemoryStore(mock_sdk, "alice", conversation_id="conv_1")
+    await store.add_messages([_user("one")])
+    await store.add_messages([_user("one"), _assistant("two")])
+
+    ids = {c.kwargs["document_id"] for c in mock_sdk.memories.create.await_args_list}
+    assert ids == {"strands-conv_1"}
+
+
+async def test_add_messages_empty_batch_is_noop(mock_sdk):
+    store = SynapMemoryStore(mock_sdk, "alice", conversation_id="conv_1")
+    await store.add_messages([{"role": "user", "content": [{"toolResult": {}}]}])
+    mock_sdk.memories.create.assert_not_awaited()
+
+
+async def test_add_messages_raises_on_failure(failing_sdk):
+    store = SynapMemoryStore(failing_sdk, "alice", conversation_id="conv_1")
+    with pytest.raises(SynapIntegrationError):
+        await store.add_messages([_user("boom")])

--- a/packages/integrations/synap-strands-agents/tests/test_stream.py
+++ b/packages/integrations/synap-strands-agents/tests/test_stream.py
@@ -1,0 +1,137 @@
+"""Tests for synap_strands_agents.stream — SynapStreamHook.
+
+Contract:
+- feeds conversation turns (MessageAddedEvent) and tool intent
+  (BeforeToolCallEvent) onto Synap's Listen stream via sdk.instance.send_message.
+- gates every send on sdk.instance.is_listening (silent no-op when not listening).
+- logs, never raises (must not abort the agent turn).
+- skips messages with no text (tool-result / tool-use-only turns).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from strands.hooks import BeforeToolCallEvent, MessageAddedEvent
+
+from synap_strands_agents.stream import SynapStreamHook
+
+
+def _streaming(mock_sdk, *, listening=True, send=None):
+    """Attach a Listen-stream instance controller to the shared mock."""
+    inst = MagicMock()
+    inst.is_listening = listening
+    inst.send_message = send or AsyncMock()
+    mock_sdk.instance = inst
+    return mock_sdk
+
+
+def _msg_event(role, text):
+    return MessageAddedEvent(agent=MagicMock(), message={"role": role, "content": [{"text": text}]})
+
+
+def _tool_event(name="search_memory", tool_input=None):
+    return BeforeToolCallEvent(
+        agent=MagicMock(),
+        selected_tool=None,
+        tool_use={"name": name, "input": tool_input or {"query": "x"}, "toolUseId": "t1"},
+        invocation_state={},
+    )
+
+
+def _hook(sdk):
+    return SynapStreamHook(sdk, conversation_id="conv_1", user_id="alice", customer_id="acme")
+
+
+# ── construction / registration ──────────────────────────────────────────────
+
+
+def test_requires_sdk():
+    with pytest.raises(ValueError):
+        SynapStreamHook(None, "conv_1", "alice")
+
+
+def test_requires_conversation_id(mock_sdk):
+    with pytest.raises(ValueError):
+        SynapStreamHook(mock_sdk, "", "alice")
+
+
+def test_requires_user_id(mock_sdk):
+    with pytest.raises(ValueError):
+        SynapStreamHook(mock_sdk, "conv_1", "")
+
+
+def test_register_hooks_subscribes_both_events(mock_sdk):
+    hook = _hook(mock_sdk)
+    registry = MagicMock()
+    hook.register_hooks(registry)
+    subscribed = {c.args[0] for c in registry.add_callback.call_args_list}
+    assert subscribed == {MessageAddedEvent, BeforeToolCallEvent}
+
+
+# ── message feed ─────────────────────────────────────────────────────────────
+
+
+async def test_user_message_feeds_stream(mock_sdk):
+    sdk = _streaming(mock_sdk)
+    await _hook(sdk)._on_message(_msg_event("user", "hello there"))
+
+    sdk.instance.send_message.assert_awaited_once()
+    kwargs = sdk.instance.send_message.await_args.kwargs
+    assert kwargs["content"] == "hello there"
+    assert kwargs["event_type"] == "user_message"
+    assert kwargs["conversation_id"] == "conv_1"
+    assert kwargs["user_id"] == "alice"
+
+
+async def test_assistant_message_event_type(mock_sdk):
+    sdk = _streaming(mock_sdk)
+    await _hook(sdk)._on_message(_msg_event("assistant", "sure, done"))
+    assert sdk.instance.send_message.await_args.kwargs["event_type"] == "assistant_message"
+
+
+async def test_no_send_when_not_listening(mock_sdk):
+    sdk = _streaming(mock_sdk, listening=False)
+    await _hook(sdk)._on_message(_msg_event("user", "hello"))
+    sdk.instance.send_message.assert_not_awaited()
+
+
+async def test_no_send_when_message_has_no_text(mock_sdk):
+    sdk = _streaming(mock_sdk)
+    event = MessageAddedEvent(
+        agent=MagicMock(),
+        message={"role": "user", "content": [{"toolResult": {"x": 1}}]},
+    )
+    await _hook(sdk)._on_message(event)
+    sdk.instance.send_message.assert_not_awaited()
+
+
+async def test_message_feed_logs_not_raises(mock_sdk):
+    sdk = _streaming(mock_sdk, send=AsyncMock(side_effect=RuntimeError("boom")))
+    await _hook(sdk)._on_message(_msg_event("user", "hello"))  # must not raise
+
+
+# ── tool-call feed ───────────────────────────────────────────────────────────
+
+
+async def test_tool_call_feeds_stream(mock_sdk):
+    sdk = _streaming(mock_sdk)
+    await _hook(sdk)._on_tool_call(_tool_event("search_memory", {"query": "budget"}))
+
+    kwargs = sdk.instance.send_message.await_args.kwargs
+    assert kwargs["event_type"] == "tool_call"
+    assert kwargs["tool_name"] == "search_memory"
+    assert kwargs["tool_args"] == {"query": "budget"}
+
+
+async def test_tool_call_no_send_when_not_listening(mock_sdk):
+    sdk = _streaming(mock_sdk, listening=False)
+    await _hook(sdk)._on_tool_call(_tool_event())
+    sdk.instance.send_message.assert_not_awaited()
+
+
+async def test_tool_call_logs_not_raises(mock_sdk):
+    sdk = _streaming(mock_sdk, send=AsyncMock(side_effect=RuntimeError("boom")))
+    await _hook(sdk)._on_tool_call(_tool_event())  # must not raise

--- a/packages/integrations/synap-strands-agents/tests/test_tools.py
+++ b/packages/integrations/synap-strands-agents/tests/test_tools.py
@@ -1,0 +1,85 @@
+"""Tests for synap_strands_agents.tools — create_synap_tools.
+
+Contract:
+- search_memory / store_memory are Strands @tool functions, directly awaitable.
+- reads (search) and writes (store) both surface SDK failures as
+  SynapIntegrationError (never a leaked raw SDK exception).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from synap_integrations_common import SynapIntegrationError
+from synap_integrations_common.testing import make_unified_response
+
+from synap_strands_agents.tools import create_synap_tools
+
+
+# ── construction / validation ───────────────────────────────────────────────
+
+
+def test_returns_two_tools(mock_sdk):
+    tools = create_synap_tools(mock_sdk, user_id="alice")
+    assert len(tools) == 2
+    names = {t.__name__ for t in tools}
+    assert names == {"search_memory", "store_memory"}
+
+
+def test_requires_sdk():
+    with pytest.raises(ValueError):
+        create_synap_tools(None, user_id="alice")
+
+
+def test_requires_user_id(mock_sdk):
+    with pytest.raises(ValueError):
+        create_synap_tools(mock_sdk, user_id="")
+
+
+# ── search_memory ────────────────────────────────────────────────────────────
+
+
+async def test_search_returns_formatted_context(mock_sdk):
+    search, _ = create_synap_tools(mock_sdk, user_id="alice", customer_id="acme")
+    out = await search("what do you know about me")
+
+    assert "User is an engineer" in out
+    mock_sdk.fetch.assert_awaited_once()
+    kwargs = mock_sdk.fetch.await_args.kwargs
+    assert kwargs["user_id"] == "alice"
+    assert kwargs["customer_id"] == "acme"
+    assert kwargs["search_query"] == ["what do you know about me"]
+
+
+async def test_search_no_results_message(mock_sdk):
+    mock_sdk.fetch.return_value = make_unified_response(formatted_context="")
+    search, _ = create_synap_tools(mock_sdk, user_id="alice")
+    out = await search("anything")
+    assert out == "No relevant memories found."
+
+
+async def test_search_raises_on_sdk_failure(failing_sdk):
+    search, _ = create_synap_tools(failing_sdk, user_id="alice")
+    with pytest.raises(SynapIntegrationError):
+        await search("boom")
+
+
+# ── store_memory ─────────────────────────────────────────────────────────────
+
+
+async def test_store_returns_confirmation(mock_sdk):
+    _, store = create_synap_tools(mock_sdk, user_id="alice", customer_id="acme")
+    out = await store("User prefers tea")
+
+    assert "ing-001" in out
+    mock_sdk.memories.create.assert_awaited_once()
+    kwargs = mock_sdk.memories.create.await_args.kwargs
+    assert kwargs["document"] == "User prefers tea"
+    assert kwargs["user_id"] == "alice"
+    assert kwargs["customer_id"] == "acme"
+
+
+async def test_store_raises_on_sdk_failure(failing_sdk):
+    _, store = create_synap_tools(failing_sdk, user_id="alice")
+    with pytest.raises(SynapIntegrationError):
+        await store("boom")

--- a/packages/mcps/synap-mcp-server/synap_mcp_server/server.py
+++ b/packages/mcps/synap-mcp-server/synap_mcp_server/server.py
@@ -14,7 +14,7 @@ from starlette.middleware.cors import CORSMiddleware
 from starlette.requests import Request
 from starlette.responses import JSONResponse
 
-from . import tools
+from . import __version__, tools
 from .config import settings
 from .context import set_token
 
@@ -41,6 +41,11 @@ mcp = FastMCP(
         allowed_origins=list(settings.cors_allow_origins),
     ),
 )
+# FastMCP builds the low-level server without a version, and that server falls back to
+# reporting the installed `mcp` library's version in the initialize handshake — which
+# contradicts the version published for this server to the MCP registry. FastMCP takes no
+# `version` argument, so set it on the wrapped server directly.
+mcp._mcp_server.version = __version__
 tools.register(mcp)
 
 # Streamable HTTP Starlette app; the MCP endpoint is mounted at /mcp.

--- a/packages/mcps/synap-mcp-server/tests/test_server.py
+++ b/packages/mcps/synap-mcp-server/tests/test_server.py
@@ -45,6 +45,36 @@ def test_health_environment_reflects_setting(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
+# Initialize handshake — advertised version
+# ---------------------------------------------------------------------------
+
+
+def test_handshake_reports_package_version():
+    """serverInfo.version must be our version, not the installed `mcp` library's.
+
+    FastMCP takes no `version` argument and the low-level server it wraps falls back to
+    pkg_version("mcp"), which would contradict the version published to the MCP registry.
+    """
+    from synap_mcp_server import __version__
+
+    opts = mcp._mcp_server.create_initialization_options()
+    assert opts.server_version == __version__
+
+
+def test_handshake_version_is_not_mcp_library_version():
+    """Guard the specific regression: reporting the mcp dependency's version."""
+    from importlib.metadata import version
+
+    opts = mcp._mcp_server.create_initialization_options()
+    assert opts.server_version != version("mcp")
+
+
+def test_handshake_reports_server_name():
+    opts = mcp._mcp_server.create_initialization_options()
+    assert opts.server_name == "synap"
+
+
+# ---------------------------------------------------------------------------
 # BearerCaptureMiddleware — token extraction
 # ---------------------------------------------------------------------------
 

--- a/packages/sdks/maximem-synap/maximem_synap/cache/anticipation_cache.py
+++ b/packages/sdks/maximem-synap/maximem_synap/cache/anticipation_cache.py
@@ -57,6 +57,20 @@ _RECALL_QUERY_PATTERNS = (
     re.compile(r"\bwhich of my\b", re.I),
     re.compile(r"\bwhat .{0,40}\b(again|earlier|last time|previously|yesterday)\b", re.I),
     re.compile(r"\bwill you use to (contact|reach|notify)\b", re.I),
+    # 2026-07-16 eval-register additions — every phrasing below was measured
+    # slipping past the gate and serving a stale bundle (issue #11):
+    #   "can you confirm my email address?"          → confirm/verify my
+    #   "what name is linked to my Uber account?"    → linked to my
+    #   "best way to contact me with updates…"       → best way to reach me
+    #   "which email are you going to use?"          → which … will you use
+    # "confirm my booking" now also bypasses — intentional over-match, costs
+    # one cloud fetch (the tie-break rule above).
+    re.compile(r"\b(confirm|verify|double.?check)\b.{0,40}\bmy\b", re.I),
+    re.compile(r"\b(linked to|associated with|registered (to|on|with)) my\b", re.I),
+    re.compile(r"\b(best|preferred) way to (reach|contact|update|notify) me\b", re.I),
+    re.compile(r"\bhow (do|will|can|should) you (reach|contact|notify) me\b", re.I),
+    re.compile(r"\bwhich .{0,40}\b(are|will) you (going to )?(use|using)\b", re.I),
+    re.compile(r"\bon (my|the) account\b", re.I),
 )
 
 
@@ -102,12 +116,40 @@ BundleStoreHook = Callable[..., None]
 LookupHook = Callable[..., None]
 
 
+def invalidate_on_write_enabled() -> bool:
+    """When true, SDK write paths drop the writing user's cached bundles.
+
+    The cloud invalidates its own Redis caches on ingest but that stops at
+    the process boundary — the in-SDK cache otherwise keeps serving the
+    pre-write view until TTL (2026-07-16 eval register issue #8). Default
+    OFF — write-path behavior is byte-identical to today."""
+    return os.environ.get("SYNAP_SDK_CACHE_INVALIDATE_ON_WRITE", "false").lower() in ("true", "1", "yes")
+
+
+def _max_entry_age_seconds(default: float) -> float:
+    """Absolute lifetime cap for a cache entry, hit-renewals included.
+
+    ``stored_at`` is a sliding lease (hits renew it), so before this cap a
+    bundle under steady traffic never expired — a pre-knowledge-update
+    snapshot could serve a retired value indefinitely (2026-07-16 eval
+    register issue #6). ``SYNAP_SDK_CACHE_MAX_ENTRY_AGE`` overrides the
+    default (2x the sliding TTL); ``0`` disables the cap."""
+    raw = os.environ.get("SYNAP_SDK_CACHE_MAX_ENTRY_AGE", "").strip()
+    if not raw:
+        return default
+    try:
+        return float(raw)
+    except ValueError:
+        return default
+
+
 @dataclass
 class _CacheEntry:
     bundle: Dict
     entity_id: str
     conversation_id: Optional[str]
     stored_at: float
+    created_at: float = 0.0
     bundle_type: str = "anticipation"
     search_queries: List[str] = field(default_factory=list)
     # Section 16 — bundle composition extensions, captured at store time so
@@ -264,11 +306,13 @@ class AnticipationCache:
         bundle_id = bundle.get("bundle_id", str(time.monotonic()))
         search_queries = bundle.get("search_queries", [])
 
+        store_time = time.monotonic()
         self._entries[bundle_id] = _CacheEntry(
             bundle=bundle,
             entity_id=entity_id,
             conversation_id=conversation_id,
-            stored_at=time.monotonic(),
+            stored_at=store_time,
+            created_at=store_time,
             bundle_type=bundle_type,
             search_queries=search_queries,
             confidence=float(bundle.get("_bundle_confidence", 0.0) or 0.0),
@@ -286,7 +330,7 @@ class AnticipationCache:
                 content = item_dict.get("content", "")
                 if not content:
                     continue
-                dedup_key = content.lower().strip()[:120]
+                dedup_key = self._dedup_key(entity_id, content)
                 if dedup_key in self._item_dedup:
                     items_deduped += 1
                     continue
@@ -315,7 +359,7 @@ class AnticipationCache:
                 content = ext_item.get("content", "")
                 if not content:
                     continue
-                dedup_key = content.lower().strip()[:120]
+                dedup_key = self._dedup_key(entity_id, content)
                 if dedup_key in self._item_dedup:
                     items_deduped += 1
                     continue
@@ -808,7 +852,10 @@ class AnticipationCache:
             return None
 
         freshest_bid = max(summary_candidates, key=lambda k: summary_candidates[k].stored_at)
-        summary_candidates[freshest_bid].stored_at = time.monotonic()
+        # Lease renewal on read follows the same rule as item hits: with
+        # TTL-hint honoring on, a read must not extend a snapshot's life.
+        if not _honor_ttl_hint_enabled():
+            summary_candidates[freshest_bid].stored_at = time.monotonic()
         return summary_candidates[freshest_bid].bundle
 
     def lookup_user_summary(
@@ -839,7 +886,8 @@ class AnticipationCache:
         if not candidates:
             return None
         freshest_bid = max(candidates, key=lambda k: candidates[k].stored_at)
-        candidates[freshest_bid].stored_at = time.monotonic()
+        if not _honor_ttl_hint_enabled():
+            candidates[freshest_bid].stored_at = time.monotonic()
         return candidates[freshest_bid].bundle
 
     def _remove_bundle(self, bundle_id: str) -> None:
@@ -849,12 +897,25 @@ class AnticipationCache:
         self._bm25_dirty = True
         self._rebuild_vocab()
 
+    def _dedup_key(self, entity_id: str, content: str) -> str:
+        """Scope-qualified item-dedup key.
+
+        Keying on content alone made the dedup set cache-GLOBAL: with the
+        one-SDK-per-instance sharing model, visitor B's byte-identical seed
+        facts were swallowed against visitor A's copy, never indexed under
+        B's bundle — so B was permanently scope_filter_excluded for that
+        content and always cold-fetched (2026-07-16 eval register issue #9).
+        Scoping the key keeps within-visitor dedup intact."""
+        return f"{entity_id}|{content.lower().strip()[:120]}"
+
     def _rebuild_vocab(self) -> None:
         self._corpus_vocab = set()
         self._item_dedup = set()
         for item in self._items:
             self._corpus_vocab.update(item.tokens)
-            self._item_dedup.add(item.content.lower().strip()[:120])
+            entry = self._entries.get(item.bundle_id)
+            entity_id = entry.entity_id if entry else "_any"
+            self._item_dedup.add(self._dedup_key(entity_id, item.content))
 
     def _effective_ttl(self, entry: "_CacheEntry", honor_hint: bool) -> float:
         """Global TTL, optionally bounded by the bundle's server-sent hint.
@@ -867,10 +928,16 @@ class AnticipationCache:
     def _evict_expired(self) -> None:
         now = time.monotonic()
         honor_hint = _honor_ttl_hint_enabled()
+        # Absolute cap on top of the sliding lease: hit-renewals move
+        # stored_at but never created_at, so no bundle outlives the cap no
+        # matter how much traffic it serves. Entries from before this field
+        # existed fall back to stored_at.
+        max_age = _max_entry_age_seconds(2.0 * self._ttl)
         expired = [
             bid
             for bid, entry in self._entries.items()
             if now - entry.stored_at > self._effective_ttl(entry, honor_hint)
+            or (max_age > 0 and now - (entry.created_at or entry.stored_at) > max_age)
         ]
         if expired:
             for bid in expired:
@@ -881,6 +948,40 @@ class AnticipationCache:
             ]
             self._bm25_dirty = True
             self._rebuild_vocab()
+
+    def invalidate_entity(self, entity_id: str) -> int:
+        """Drop every bundle whose funnel scope is ``entity_id``.
+
+        Write-path hook (2026-07-16 eval register issue #8): the cloud
+        invalidates its Redis L1/L2/L3 on ingest, but that stops at the
+        process boundary — nothing ever told this in-process cache a write
+        happened, so a pre-write bundle kept serving the old view for its
+        whole TTL. Callers with a write path (SDK ingest, the playground's
+        turn ingestion) invalidate the writing user's scope; the next
+        lookup cold-fetches and the follow-up push repopulates.
+
+        Returns the number of bundles dropped. ``"_any"``-scoped bundles
+        are left alone — they carry client-shared content, not the written
+        user's state.
+        """
+        if not entity_id:
+            return 0
+        doomed = [
+            bid for bid, entry in self._entries.items()
+            if entry.entity_id == entity_id
+        ]
+        for bid in doomed:
+            del self._entries[bid]
+        if doomed:
+            doomed_set = set(doomed)
+            self._items = [i for i in self._items if i.bundle_id not in doomed_set]
+            self._bm25_dirty = True
+            self._rebuild_vocab()
+            logger.info(
+                "Cache invalidated on write: entity=%s bundles_dropped=%d",
+                entity_id, len(doomed),
+            )
+        return len(doomed)
 
     def clear(self) -> None:
         self._entries.clear()

--- a/packages/sdks/maximem-synap/maximem_synap/cache/test_cache_hardening.py
+++ b/packages/sdks/maximem-synap/maximem_synap/cache/test_cache_hardening.py
@@ -1,0 +1,137 @@
+"""2026-07-16 eval-register hardening: absolute entry age cap (#6),
+scope-qualified item dedup (#9), and write-path invalidation (#8).
+
+Contracts pinned here:
+- The sliding lease (hit renews ``stored_at``) is now bounded by an absolute
+  cap on ``created_at`` — default 2x TTL, ``SYNAP_SDK_CACHE_MAX_ENTRY_AGE``
+  overrides, ``0`` disables. Before this, a bundle hit at least once per TTL
+  window never expired.
+- Item dedup is keyed per bundle scope, so two visitors' byte-identical seed
+  facts both index (previously the second visitor's copy was swallowed and
+  scope-excluded forever).
+- ``invalidate_entity`` drops exactly the given scope's bundles; the SDK
+  write paths call it only when SYNAP_SDK_CACHE_INVALIDATE_ON_WRITE is on
+  (default off).
+"""
+
+import time
+
+from maximem_synap.cache.anticipation_cache import (
+    AnticipationCache,
+    invalidate_on_write_enabled,
+)
+
+
+def _bundle(bundle_id, entity, content, queries=("account file records",)):
+    return {
+        "bundle_id": bundle_id,
+        "_anticipation_user_id": entity,
+        "_anticipation_conversation_id": None,
+        "items_by_type": {
+            "facts": [{"content": content, "confidence": 0.9}],
+        },
+        "search_queries": list(queries),
+    }
+
+
+SEED_FACT = "the company refund policy allows requests within thirty days"
+QUERY = "refund policy requests thirty days"
+
+
+class TestAbsoluteAgeCap:
+    def test_hit_renewal_cannot_outlive_the_cap(self, monkeypatch):
+        monkeypatch.delenv("SYNAP_SDK_CACHE_MAX_ENTRY_AGE", raising=False)
+        monkeypatch.delenv("SYNAP_SDK_CACHE_HONOR_TTL_HINT", raising=False)
+        cache = AnticipationCache(ttl_seconds=300)
+        cache.store(_bundle("b1", "alice", SEED_FACT))
+        entry = cache._entries["b1"]
+        # Simulate a bundle kept alive by steady hits: lease is fresh but the
+        # entry was created beyond the 2x-TTL cap.
+        entry.stored_at = time.monotonic()
+        entry.created_at = time.monotonic() - 601
+        assert cache.lookup(search_query=[QUERY], entity_id="alice") is None
+        assert "b1" not in cache._entries
+
+    def test_env_zero_disables_the_cap(self, monkeypatch):
+        monkeypatch.setenv("SYNAP_SDK_CACHE_MAX_ENTRY_AGE", "0")
+        monkeypatch.delenv("SYNAP_SDK_CACHE_HONOR_TTL_HINT", raising=False)
+        cache = AnticipationCache(ttl_seconds=300)
+        cache.store(_bundle("b1", "alice", SEED_FACT))
+        entry = cache._entries["b1"]
+        entry.stored_at = time.monotonic()
+        entry.created_at = time.monotonic() - 10_000
+        assert cache.lookup(search_query=[QUERY], entity_id="alice") is not None
+
+    def test_fresh_entry_unaffected(self, monkeypatch):
+        monkeypatch.delenv("SYNAP_SDK_CACHE_MAX_ENTRY_AGE", raising=False)
+        cache = AnticipationCache(ttl_seconds=300)
+        cache.store(_bundle("b1", "alice", SEED_FACT))
+        assert cache.lookup(search_query=[QUERY], entity_id="alice") is not None
+
+    def test_pre_field_entries_fall_back_to_stored_at(self, monkeypatch):
+        """Entries with created_at=0.0 (pre-upgrade) must not insta-expire."""
+        monkeypatch.delenv("SYNAP_SDK_CACHE_MAX_ENTRY_AGE", raising=False)
+        cache = AnticipationCache(ttl_seconds=300)
+        cache.store(_bundle("b1", "alice", SEED_FACT))
+        cache._entries["b1"].created_at = 0.0
+        assert cache.lookup(search_query=[QUERY], entity_id="alice") is not None
+
+
+class TestScopedDedup:
+    def test_identical_seed_facts_index_for_both_visitors(self):
+        cache = AnticipationCache(ttl_seconds=300)
+        cache.store(_bundle("bundle_a", "visitor_a", SEED_FACT))
+        cache.store(_bundle("bundle_b", "visitor_b", SEED_FACT))
+        assert len(cache._items) == 2
+        for visitor in ("visitor_a", "visitor_b"):
+            result = cache.lookup(search_query=[QUERY], entity_id=visitor)
+            assert result is not None, f"{visitor} should hit its own copy"
+
+    def test_within_scope_dedup_still_applies(self):
+        cache = AnticipationCache(ttl_seconds=300)
+        cache.store(_bundle("bundle_1", "visitor_a", SEED_FACT))
+        cache.store(_bundle("bundle_2", "visitor_a", SEED_FACT))
+        assert len(cache._items) == 1
+
+    def test_rebuild_preserves_scoped_keys(self):
+        cache = AnticipationCache(ttl_seconds=300)
+        cache.store(_bundle("bundle_a", "visitor_a", SEED_FACT))
+        cache.store(_bundle("bundle_b", "visitor_b", SEED_FACT))
+        cache._remove_bundle("bundle_a")
+        # After the rebuild, visitor_b's copy must survive and still hit.
+        assert cache.lookup(search_query=[QUERY], entity_id="visitor_b") is not None
+
+
+class TestInvalidateEntity:
+    def test_drops_only_the_given_scope(self):
+        cache = AnticipationCache(ttl_seconds=300)
+        cache.store(_bundle("bundle_a", "visitor_a", SEED_FACT))
+        cache.store(_bundle("bundle_b", "visitor_b", SEED_FACT))
+        dropped = cache.invalidate_entity("visitor_a")
+        assert dropped == 1
+        assert cache.lookup(search_query=[QUERY], entity_id="visitor_a") is None
+        assert cache.lookup(search_query=[QUERY], entity_id="visitor_b") is not None
+
+    def test_any_scope_bundles_survive(self):
+        cache = AnticipationCache(ttl_seconds=300)
+        shared = _bundle("bundle_shared", None, SEED_FACT)
+        shared.pop("_anticipation_user_id")
+        cache.store(shared)  # lands under "_any"
+        assert cache.invalidate_entity("visitor_a") == 0
+        assert "bundle_shared" in cache._entries
+
+    def test_empty_entity_is_a_noop(self):
+        cache = AnticipationCache(ttl_seconds=300)
+        cache.store(_bundle("bundle_a", "visitor_a", SEED_FACT))
+        assert cache.invalidate_entity("") == 0
+        assert len(cache._entries) == 1
+
+
+class TestInvalidateOnWriteFlag:
+    def test_default_off(self, monkeypatch):
+        monkeypatch.delenv("SYNAP_SDK_CACHE_INVALIDATE_ON_WRITE", raising=False)
+        assert invalidate_on_write_enabled() is False
+
+    def test_env_on(self, monkeypatch):
+        monkeypatch.setenv("SYNAP_SDK_CACHE_INVALIDATE_ON_WRITE", "true")
+        assert invalidate_on_write_enabled() is True

--- a/packages/sdks/maximem-synap/maximem_synap/cache/test_recall_bypass.py
+++ b/packages/sdks/maximem-synap/maximem_synap/cache/test_recall_bypass.py
@@ -114,6 +114,14 @@ class TestRecallHeuristic:
         "do you remember my seating preference?",
         "what did I say about my budget earlier?",
         "is my address still in your records?",
+        # 2026-07-16 eval register #11 — measured slipping past the gate:
+        "can you confirm my email address?",
+        "what's the best way to contact me with updates about my rides?",
+        "what name is linked to my Uber account?",
+        "can you verify my phone number?",
+        "which email are you going to use?",
+        "how will you reach me?",
+        "is there a phone number on my account?",
     ]
     NOT_RECALL = [
         "book a ride to the airport",

--- a/packages/sdks/maximem-synap/maximem_synap/sdk.py
+++ b/packages/sdks/maximem-synap/maximem_synap/sdk.py
@@ -1379,6 +1379,27 @@ class MaximemSynapSDK:
                 "SDK not initialized. Call await sdk.initialize() first."
             )
 
+    def _invalidate_anticipation_on_write(
+        self,
+        user_id: Optional[str] = None,
+        customer_id: Optional[str] = None,
+    ) -> None:
+        """Drop the writing user's cached anticipation bundles.
+
+        Called from write paths (record_message / record_messages_batch /
+        ingest_transcript) so a pre-write bundle can't keep serving the old
+        view for its whole TTL. Gated by SYNAP_SDK_CACHE_INVALIDATE_ON_WRITE
+        (default off). Over-invalidation on a failed write is safe — it only
+        costs the next lookup a cold fetch.
+        """
+        from .cache.anticipation_cache import invalidate_on_write_enabled
+
+        if self._anticipation_cache is None or not invalidate_on_write_enabled():
+            return
+        for eid in {user_id, customer_id}:
+            if eid:
+                self._anticipation_cache.invalidate_entity(str(eid))
+
     async def _get_auth_context(self, correlation_id: Optional[str] = None):
         """Get auth context for requests."""
         self._ensure_initialized()
@@ -1590,6 +1611,9 @@ class ConversationInterface:
                 )
             except Exception as e:
                 logger.warning("Failed to append turn to ST store: %s", e)
+        self._sdk._invalidate_anticipation_on_write(
+            user_id=user_id, customer_id=customer_id
+        )
         return result
 
     async def record_messages_batch(
@@ -1630,6 +1654,10 @@ class ConversationInterface:
                     )
                 except Exception as e:
                     logger.warning("Failed to append batch turn to ST store: %s", e)
+        for msg in messages:
+            self._sdk._invalidate_anticipation_on_write(
+                user_id=msg.get("user_id"), customer_id=msg.get("customer_id")
+            )
         return result
 
     async def ingest_transcript(
@@ -1759,6 +1787,9 @@ class ConversationInterface:
                 latency_ms=latency_ms,
                 status="success",
                 scope="conversation",
+            )
+            self._sdk._invalidate_anticipation_on_write(
+                user_id=user_id, customer_id=customer_id
             )
             return response
 


### PR DESCRIPTION
Manual run of `scripts/sync_to_public.sh` from the private monorepo.

The automated **Sync SDK to Public Repo** workflow has failed on every run since 2026-07-17 — GitHub Actions jobs are not starting at all (`"The job was not started because recent account payments have failed or your spending limit needs to be increased"`). Several merges' worth of changes never reached this mirror, so this catches it up manually until billing is restored.

## Contents

**`packages/integrations/synap-eve`** — **new**: `@maximem/synap-eve`, the Synap memory integration for [Vercel eve](https://vercel.com/eve) agents (monorepo #922, #926). Two native eve seams: `createSynapSearchTool` / `createSynapStoreTool` for `agent/tools/*.ts`, and `createSynapInstructions`, a per-turn `defineDynamic` resolver that injects Synap's short-term context into the system prompt from `agent/instructions/`. Identity auto-scopes from the eve session (`ctx.session.auth.current.principalId`); reads degrade, writes raise. 13 files.

**`packages/integrations/`** — adds `synap-strands-agents`, `synap-camel-ai`, `synap-smolagents` (monorepo #920, #921).

**`README.md`** — matching integration-table rows for all four new packages.

**`packages/mcps/synap-mcp-server`** — report our own version in the `initialize` handshake instead of the installed `mcp` library's (monorepo #923). The server advertised `1.28.1` (the dependency's version) while `ai.maximem/synap` is published to the MCP registry at `0.1.0`; clients comparing the listing to the live handshake saw a contradiction. Adds 3 regression tests.

**`packages/sdks/maximem-synap`** — anticipation cache hardening and `sdk.py` catch-up.

## Published packages

| Package | Registry | Version |
|---|---|---|
| `@maximem/synap-eve` | npm | `0.1.0` |
| `maximem-synap-strands-agents` | PyPI | see monorepo #920 |
| `maximem-synap-camel-ai` | PyPI | see monorepo #921 |
| `maximem-synap-smolagents` | PyPI | see monorepo #921 |

## Verification

- Synced via `scripts/sync_to_public.sh`, whose scrubber passed (exit 0)
- Additionally scanned the diff independently for credentials (API keys, private keys, tokens) and internal hostnames/IPs — clean
- No stray `.env`/`.pem`/credential files in the new packages
- `synap-eve`: `tsc --noEmit` clean, 26/26 vitest tests pass
- 56 files, +7003/−7

🤖 Generated with [Claude Code](https://claude.com/claude-code)