### PR TITLE
fix(skills): stop documenting SYNAP_INSTANCE_ID as required setup

### DIFF
--- a/skills/synap-codex/examples/python-minimal.py
+++ b/skills/synap-codex/examples/python-minimal.py
@@ -3,8 +3,10 @@ Minimal Synap example — Python, no framework.
 
 Run after:
     pip install maximem-synap
-    export SYNAP_INSTANCE_ID=inst_...
     export SYNAP_API_KEY=synap_...
+
+The instance is resolved from the API key on initialize(); SYNAP_INSTANCE_ID is
+only needed to pin a specific instance.
 """
 
 import asyncio
@@ -12,7 +14,7 @@ from maximem_synap import MaximemSynapSDK
 
 
 async def main():
-    sdk = MaximemSynapSDK()         # reads env vars
+    sdk = MaximemSynapSDK()         # reads SYNAP_API_KEY from the environment
     await sdk.initialize()
 
     try:

--- a/skills/synap-codex/reference/frameworks/nemo-agent-toolkit.md
+++ b/skills/synap-codex/reference/frameworks/nemo-agent-toolkit.md
@@ -58,8 +58,8 @@ Then in the NAT YAML:
 memory:
   type: synap
   config:
-    instance_id: ${SYNAP_INSTANCE_ID}
     api_key: ${SYNAP_API_KEY}
+    # instance_id: ${SYNAP_INSTANCE_ID}   # optional — resolved from the key if omitted
     mode: accurate
     customer_id: acme
 ```
@@ -72,7 +72,6 @@ For programmatic setup outside YAML — when you don't want to manage the SDK li
 from synap_nemo_agent_toolkit import synap_memory_client
 
 editor = synap_memory_client(
-    instance_id=os.environ["SYNAP_INSTANCE_ID"],
     api_key=os.environ["SYNAP_API_KEY"],
     customer_id="acme",
     mode="accurate",

--- a/skills/synap-codex/reference/production.md
+++ b/skills/synap-codex/reference/production.md
@@ -6,7 +6,7 @@ Work through this before the user's first production deployment, and again befor
 
 - [ ] `SYNAP_API_KEY` is in a secret manager (AWS Secrets Manager, GCP Secret Manager, Vault, Doppler, etc.) — never in code, never in `.env` files committed to git.
 - [ ] Separate API keys per environment (dev / staging / prod). Revoke and rotate quarterly or on staff changes.
-- [ ] `SYNAP_INSTANCE_ID` for production points at a **separate instance** from staging/dev. Do not share an instance across environments — memories will mix.
+- [ ] The production API key resolves to a **separate instance** from staging/dev (the instance is resolved from the key, so this follows from using separate keys — verify it rather than assuming). Do not share an instance across environments — memories will mix.
 
 ## Scoping
 

--- a/skills/synap-codex/reference/sdk-setup.md
+++ b/skills/synap-codex/reference/sdk-setup.md
@@ -43,11 +43,19 @@ Cloudflare Workers, Bun, Deno Deploy, or Node-only Lambda runtimes.
 ## Environment variables (the canonical pattern)
 
 ```bash
-export SYNAP_INSTANCE_ID="inst_a1b2c3d4e5f67890"
 export SYNAP_API_KEY="synap_..."
 ```
 
-With these set, the SDK auto-loads them — no constructor args needed.
+With this set, the SDK auto-loads it — no constructor args needed. The instance is
+resolved from the API key during `initialize()`, so `SYNAP_INSTANCE_ID` is **not**
+required.
+
+Set it only when a key has access to more than one instance and you want to pin a
+specific one:
+
+```bash
+export SYNAP_INSTANCE_ID="inst_a1b2c3d4e5f67890"   # optional
+```
 
 ## Basic init
 
@@ -136,7 +144,6 @@ config = SDKConfig(
 )
 
 sdk = MaximemSynapSDK(
-    instance_id=os.environ["SYNAP_INSTANCE_ID"],
     api_key=os.environ["SYNAP_API_KEY"],
     config=config,
 )

--- a/skills/synap/AGENTS.md
+++ b/skills/synap/AGENTS.md
@@ -45,7 +45,7 @@ Edge/Workers/Bun/Deno/Node-only-Lambda. Env vars: `SYNAP_API_KEY` (required),
 import os
 from maximem_synap import MaximemSynapSDK
 
-sdk = MaximemSynapSDK()        # reads env vars
+sdk = MaximemSynapSDK()        # reads SYNAP_API_KEY; instance resolved from the key
 await sdk.initialize()
 try:
     # ... use sdk ...
@@ -224,7 +224,7 @@ const model = synap.wrap(anthropic("claude-sonnet-4-6"), { userId: "alice" });
 
 ## Defaults to use unless told otherwise
 
-- Read env vars `SYNAP_INSTANCE_ID` and `SYNAP_API_KEY`. Never hardcode.
+- Read env var `SYNAP_API_KEY`. Never hardcode. `SYNAP_INSTANCE_ID` is optional — the instance is resolved from the key.
 - Ingestion: `mode="long-range"`, `document_type="ai-chat-conversation"`.
 - Retrieval: `mode="fast"`, `max_results=10`.
 - Always pass `user_id`. Add `customer_id` only when multi-tenant.

--- a/skills/synap/SKILL.md
+++ b/skills/synap/SKILL.md
@@ -112,10 +112,9 @@ import os
 from maximem_synap import MaximemSynapSDK
 
 sdk = MaximemSynapSDK(
-    instance_id=os.environ["SYNAP_INSTANCE_ID"],
     api_key=os.environ["SYNAP_API_KEY"],
 )
-await sdk.initialize()      # validates key, opens connection
+await sdk.initialize()      # validates key, resolves the instance, opens connection
 # ... use sdk ...
 await sdk.shutdown()        # flush telemetry, close connections
 ```
@@ -175,7 +174,7 @@ If the user's framework isn't in the list (rare), they wire `sdk.memories.create
 
 When generating code, default to:
 
-- Read environment variables `SYNAP_INSTANCE_ID` and `SYNAP_API_KEY`. Never hardcode.
+- Read the environment variable `SYNAP_API_KEY`. Never hardcode. `SYNAP_INSTANCE_ID` is optional — the instance is resolved from the key.
 - Ingestion `mode="long-range"`, `document_type="ai-chat-conversation"`.
 - Retrieval `mode="fast"`, `max_results=10`.
 - Always pass `user_id`. Add `customer_id` only if the user mentions multi-tenant / B2B / orgs.

--- a/skills/synap/examples/python-minimal.py
+++ b/skills/synap/examples/python-minimal.py
@@ -3,8 +3,10 @@ Minimal Synap example — Python, no framework.
 
 Run after:
     pip install maximem-synap
-    export SYNAP_INSTANCE_ID=inst_...
     export SYNAP_API_KEY=synap_...
+
+The instance is resolved from the API key on initialize(); SYNAP_INSTANCE_ID is
+only needed to pin a specific instance.
 """
 
 import asyncio
@@ -12,7 +14,7 @@ from maximem_synap import MaximemSynapSDK
 
 
 async def main():
-    sdk = MaximemSynapSDK()         # reads env vars
+    sdk = MaximemSynapSDK()         # reads SYNAP_API_KEY from the environment
     await sdk.initialize()
 
     try:

--- a/skills/synap/reference/frameworks/nemo-agent-toolkit.md
+++ b/skills/synap/reference/frameworks/nemo-agent-toolkit.md
@@ -58,8 +58,8 @@ Then in the NAT YAML:
 memory:
   type: synap
   config:
-    instance_id: ${SYNAP_INSTANCE_ID}
     api_key: ${SYNAP_API_KEY}
+    # instance_id: ${SYNAP_INSTANCE_ID}   # optional — resolved from the key if omitted
     mode: accurate
     customer_id: acme
 ```
@@ -72,7 +72,6 @@ For programmatic setup outside YAML — when you don't want to manage the SDK li
 from synap_nemo_agent_toolkit import synap_memory_client
 
 editor = synap_memory_client(
-    instance_id=os.environ["SYNAP_INSTANCE_ID"],
     api_key=os.environ["SYNAP_API_KEY"],
     customer_id="acme",
     mode="accurate",

--- a/skills/synap/reference/production.md
+++ b/skills/synap/reference/production.md
@@ -6,7 +6,7 @@ Work through this before the user's first production deployment, and again befor
 
 - [ ] `SYNAP_API_KEY` is in a secret manager (AWS Secrets Manager, GCP Secret Manager, Vault, Doppler, etc.) — never in code, never in `.env` files committed to git.
 - [ ] Separate API keys per environment (dev / staging / prod). Revoke and rotate quarterly or on staff changes.
-- [ ] `SYNAP_INSTANCE_ID` for production points at a **separate instance** from staging/dev. Do not share an instance across environments — memories will mix.
+- [ ] The production API key resolves to a **separate instance** from staging/dev (the instance is resolved from the key, so this follows from using separate keys — verify it rather than assuming). Do not share an instance across environments — memories will mix.
 
 ## Scoping
 

--- a/skills/synap/reference/sdk-setup.md
+++ b/skills/synap/reference/sdk-setup.md
@@ -43,11 +43,19 @@ Cloudflare Workers, Bun, Deno Deploy, or Node-only Lambda runtimes.
 ## Environment variables (the canonical pattern)
 
 ```bash
-export SYNAP_INSTANCE_ID="inst_a1b2c3d4e5f67890"
 export SYNAP_API_KEY="synap_..."
 ```
 
-With these set, the SDK auto-loads them — no constructor args needed.
+With this set, the SDK auto-loads it — no constructor args needed. The instance is
+resolved from the API key during `initialize()`, so `SYNAP_INSTANCE_ID` is **not**
+required.
+
+Set it only when a key has access to more than one instance and you want to pin a
+specific one:
+
+```bash
+export SYNAP_INSTANCE_ID="inst_a1b2c3d4e5f67890"   # optional
+```
 
 ## Basic init
 
@@ -136,7 +144,6 @@ config = SDKConfig(
 )
 
 sdk = MaximemSynapSDK(
-    instance_id=os.environ["SYNAP_INSTANCE_ID"],
     api_key=os.environ["SYNAP_API_KEY"],
     config=config,
 )


### PR DESCRIPTION
Supersedes #8.

## The bug

The SDK resolves the instance from the API key during `initialize()` — `sdk.py`:

> `instance_id`: Optional instance ID. **If omitted, resolved from the API key on `initialize()` via `GET /api/v1/auth/whoami`.**

But the skill docs still instruct users to `export SYNAP_INSTANCE_ID=inst_...` as required setup and to pass `instance_id=os.environ["SYNAP_INSTANCE_ID"]` into the constructor. Following them verbatim demands a value that isn't needed — and `os.environ[...]` raises `KeyError` if it's absent.

`skills/synap` was already contradicting itself: `AGENTS.md:40` correctly called the var optional while `SKILL.md` and the examples presented it as mandatory.

## Both directories

`skills/synap-codex` was created by copying `skills/synap` — I diffed them and `examples/python-minimal.py` was byte-identical, so the stale guidance was duplicated rather than fixed. This PR corrects both and leaves the shared files in parity.

## What changed

- `examples/python-minimal.py` — drop the `SYNAP_INSTANCE_ID` export from the run instructions
- `reference/sdk-setup.md` — "canonical pattern" is now `SYNAP_API_KEY` alone; instance-pinning shown separately as optional
- `SKILL.md`, `AGENTS.md` — constructor and "defaults to use" no longer imply the var is required
- `reference/production.md` — reframed around the production *key* resolving to a separate instance
- `reference/frameworks/nemo-agent-toolkit.md` — field kept but commented and marked optional, since that integration genuinely accepts it (`plugin.py:83` falls back to `os.environ.get("SYNAP_INSTANCE_ID", "")`)

Every surviving mention now reads as explicitly optional. Verified: no `instance_id=os.environ[...]` patterns remain, both Python examples compile, and the five shared files are identical across the two skill dirs.

## Why not just rebase #8

#8 was 18 commits behind with conflicts in 9 files, and covered only `skills/synap` — it predates `synap-codex` entirely, so merging it would have left half the stale content in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)