### PR TITLE
sync: fix(sdk): key the singleton registry on the credential, not an unresolved instance_id

### DIFF
--- a/packages/sdks/maximem-synap/maximem_synap/_version.py
+++ b/packages/sdks/maximem-synap/maximem_synap/_version.py
@@ -1,3 +1,3 @@
 """Version information for MaximemSynap SDK."""
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"

--- a/packages/sdks/maximem-synap/maximem_synap/registry.py
+++ b/packages/sdks/maximem-synap/maximem_synap/registry.py
@@ -1,5 +1,7 @@
 """SDK instance registry for singleton pattern."""
 
+import hashlib
+import os
 import threading
 from typing import Dict, Optional, TYPE_CHECKING
 
@@ -7,8 +9,36 @@ if TYPE_CHECKING:
     from .sdk import MaximemSynapSDK
 
 
+def build_registry_key(instance_id: str, api_key: Optional[str]) -> str:
+    """Derive the registry slot an SDK belongs in.
+
+    ``instance_id`` keys the singleton, but it is optional and normally empty
+    at construction time — it is resolved from the API key during
+    ``initialize()``. Keying on it directly therefore put every
+    ``MaximemSynapSDK(api_key=...)`` in one process onto the single ``""``
+    slot, and the second one adopted the first's state, credentials included.
+
+    So when no ``instance_id`` is supplied, fall back to the credential that
+    *will* resolve the identity. It is stored as a truncated SHA-256 digest,
+    never in plaintext, so a registry dump or a log line cannot leak it.
+
+    ``SYNAP_INSTANCE_ID`` is deliberately not consulted. The SDK applies that
+    fallback after the registry lookup, and honouring it here would put two
+    different credentials back onto one slot whenever the env var happens to
+    be set.
+    """
+    if instance_id:
+        return instance_id
+    key = api_key or os.environ.get("SYNAP_API_KEY", "")
+    if not key:
+        # Nothing to key on. The SDK cannot initialize without a credential
+        # anyway, so preserve the historical empty-string slot.
+        return ""
+    return f"apikey:{hashlib.sha256(key.encode()).hexdigest()[:32]}"
+
+
 class SDKRegistry:
-    """Registry for SDK instances (singleton per instance_id)."""
+    """Registry for SDK instances (singleton per registry key)."""
 
     _instances: Dict[str, "MaximemSynapSDK"] = {}
     _lock = threading.Lock()
@@ -30,6 +60,21 @@ class SDKRegistry:
         """Unregister an SDK instance."""
         with cls._lock:
             cls._instances.pop(instance_id, None)
+
+    @classmethod
+    def unregister_if_owner(cls, key: str, sdk: "MaximemSynapSDK") -> None:
+        """Drop ``key`` only if it still maps to ``sdk``'s state.
+
+        A shutting-down SDK must not evict whoever currently holds its old
+        slot. The comparison is on ``__dict__`` identity, not object identity:
+        a second SDK constructed for the same key aliases the registered one's
+        ``__dict__``, so shutting either of them down closes the one set of
+        transports both share — and the entry has to go with them.
+        """
+        with cls._lock:
+            existing = cls._instances.get(key)
+            if existing is not None and existing.__dict__ is sdk.__dict__:
+                del cls._instances[key]
 
     @classmethod
     def clear(cls) -> None:

--- a/packages/sdks/maximem-synap/maximem_synap/sdk.py
+++ b/packages/sdks/maximem-synap/maximem_synap/sdk.py
@@ -9,7 +9,7 @@ from datetime import datetime, timezone
 from typing import Any, Callable, Dict, List, Optional, Union
 
 from .config_utils import configure_logging, get_default_storage_path, merge_config
-from .registry import SDKRegistry
+from .registry import SDKRegistry, build_registry_key
 from .models.config import SDKConfig, TimeoutConfig, RetryPolicy
 from .models.context import (
     ContextResponse,
@@ -745,19 +745,27 @@ class MaximemSynapSDK:
 
         Args:
             instance_id: Optional instance ID. If omitted, resolved from the
-                API key on initialize() via GET /api/v1/auth/whoami.
+                API key on initialize() via GET /api/v1/auth/whoami, and the
+                singleton is keyed on the API key instead.
             api_key: Synap API key. If omitted, read from SYNAP_API_KEY env var.
             config: Optional configuration overrides.
             _force_new: Force create new instance (for testing).
         """
-        # Check singleton registry
+        # Check singleton registry. Keyed on the explicit instance_id when
+        # there is one, on the credential otherwise — see build_registry_key.
+        registry_key = build_registry_key(instance_id, api_key)
         if not _force_new:
-            existing = SDKRegistry.get(instance_id)
+            existing = SDKRegistry.get(registry_key)
             if existing is not None:
                 # Return existing instance - copy its state
                 self.__dict__ = existing.__dict__
                 return
 
+        # The slot this SDK actually occupies, so shutdown() removes the entry
+        # it created rather than one derived from a since-resolved instance_id.
+        # None for _force_new instances: they are never registered, so they
+        # have nothing to remove.
+        self._registry_key: Optional[str] = None if _force_new else registry_key
         self.instance_id = instance_id or os.environ.get("SYNAP_INSTANCE_ID", "")
         validate_instance_id(self.instance_id)
         self._api_key = api_key
@@ -844,7 +852,7 @@ class MaximemSynapSDK:
 
         # Register in singleton registry
         if not _force_new:
-            SDKRegistry.register(instance_id, self)
+            SDKRegistry.register(registry_key, self)
 
     def configure(self, **kwargs) -> None:
         """Update SDK configuration.
@@ -1156,8 +1164,11 @@ class MaximemSynapSDK:
         if self._cache_manager:
             self._cache_manager.close()
 
-        # Unregister from singleton
-        SDKRegistry.unregister(self.instance_id)
+        # Unregister from singleton. Keyed on the slot this SDK was actually
+        # registered under — self.instance_id may have been resolved by
+        # initialize() since, and a _force_new SDK holds no slot at all.
+        if self._registry_key is not None:
+            SDKRegistry.unregister_if_owner(self._registry_key, self)
 
         self._initialized = False
         logger.info("SDK shutdown complete")


### PR DESCRIPTION
Catch-up sync from the private monorepo (`maximem-ai/maximem_synap@9d217b1f`, PR #945).

## What changed

`SDKRegistry` was keyed on `instance_id`, which is optional and normally empty at construction time — it is resolved from the API key later, in `initialize()` via `/api/v1/auth/whoami`. Every SDK built the documented way (`MaximemSynapSDK(api_key=...)`) therefore landed on the single `""` slot, and the second one executed `self.__dict__ = existing.__dict__`, aliasing the first's state rather than copying it.

A process constructing SDKs for two different API keys — the per-tenant B2B backend the README leads with — silently authenticated the second tenant as the first: `_credential_manager` is shared, so `HTTPTransport` sent tenant A's bearer token on every request the second SDK made. Reads returned A's memory; writes committed into A's instance. It was silent: no exception, no log line, and `sdk_a is sdk_b` is `False`, so the two looked genuinely distinct in a debugger.

## The fix

- Derive the registry slot from the credential when no `instance_id` is supplied (`apikey:<sha256[:32]>`, never plaintext, so a registry dump cannot leak it). An explicit `instance_id` keys byte-for-byte as before.
- Record the slot each SDK actually occupied. Registration used the constructor's `instance_id` while `shutdown()` unregistered `self.instance_id`, which `initialize()` may have overwritten in between — leaving a stale entry serving an SDK whose transports were already closed. Removal is now ownership-guarded, so a `_force_new` SDK (never registered) can no longer evict the live singleton on teardown.

Backward compatibility is pinned by tests in the monorepo: an identical API key still yields one singleton, and an explicit `instance_id` still behaves exactly as before.

## Release

Version bumped `0.4.0` → `0.4.1` and **already published to PyPI**: https://pypi.org/project/maximem-synap/0.4.1/