### PR TITLE
docs(skills): the singleton keys on the API key, not instance_id

### DIFF
--- a/skills/synap-codex/reference/production.md
+++ b/skills/synap-codex/reference/production.md
@@ -19,7 +19,7 @@ Work through this before the user's first production deployment, and again befor
 
 - [ ] `await sdk.initialize()` runs once at process start, not per-request.
 - [ ] `await sdk.shutdown()` runs on graceful shutdown (SIGTERM handler, FastAPI lifespan, Lambda extension, etc.).
-- [ ] Single SDK instance per `instance_id` per process — singleton behavior is intentional, don't fight it.
+- [ ] Single SDK instance per API key per process — singleton behavior is intentional, don't fight it. One key per instance: two keys on one instance give two SDKs and two streams.
 - [ ] In serverless, the SDK is module-level and initialized lazily on first invocation; cold-start latency is documented.
 
 ## Read path

--- a/skills/synap-codex/reference/sdk-setup.md
+++ b/skills/synap-codex/reference/sdk-setup.md
@@ -104,15 +104,21 @@ The JS API is flat and camelCase, and is **not** identical to Python: there is n
 
 ## Singleton behavior
 
-By design, constructing `MaximemSynapSDK` twice with the same `instance_id` returns the same instance:
+By design, constructing `MaximemSynapSDK` twice with the same **API key** returns the same live SDK:
 
 ```python
-a = MaximemSynapSDK(instance_id="inst_...", api_key="...")
-b = MaximemSynapSDK(instance_id="inst_...", api_key="...")
-assert a is b   # True
+a = MaximemSynapSDK(api_key="sk-...")
+b = MaximemSynapSDK(api_key="sk-...")
+# One live SDK: b shares a's connections, caches and credentials.
+# Note: `a is b` is False. They share internal state, they are not the same
+# object, so use the SDK rather than identity-checking it.
 ```
 
 This prevents duplicate connections from multi-module imports. Don't fight it. For tests, pass `_force_new=True`.
+
+Different API keys give you different SDKs, so serving several tenants from one process is supported. Two keys issued against the *same* instance are the exception: each key is its own identity, so you get two SDKs, two Listen streams and two caches for one instance. `initialize()` warns when it sees that. Use one key per instance per process.
+
+Passing `instance_id` explicitly still keys on the id, so two keys under one id share a single SDK on the first key. You do not need it: your API key already identifies your instance.
 
 ## Production-grade init with config
 

--- a/skills/synap/AGENTS.md
+++ b/skills/synap/AGENTS.md
@@ -56,7 +56,7 @@ finally:
 
 TypeScript is **not** identical — the JS API is flat and camelCase: `const sdk = createClient({ apiKey })` from `@maximem/synap-js-sdk`, then `await sdk.init()` … `await sdk.shutdown()`. Write with `sdk.addMemory({ userId, customerId, messages, mode })`; read with `sdk.fetchUserContext({ userId, searchQuery, mode })` or `sdk.getContextForPrompt({ conversationId })`. There is no `MaximemSynapSDK` class and no `sdk.memories` / `sdk.conversation` namespaces.
 
-The SDK is a **singleton per `instance_id`**. Don't fight it.
+The SDK is a **singleton per API key**. Don't fight it.
 
 ## Two operations to know
 

--- a/skills/synap/SKILL.md
+++ b/skills/synap/SKILL.md
@@ -133,7 +133,7 @@ await sdk.shutdown();
 
 The JS SDK spawns the Python SDK as a subprocess — it needs **Python 3.11+ on the host** and does not run on Edge/Workers/Bun/Deno/Node-only-Lambda. There is no `MaximemSynapSDK` class and no `sdk.memories` / `sdk.conversation` namespaces in JS.
 
-The Python SDK is a **singleton per `instance_id`** — constructing twice with the same id returns the same instance. This is intentional; do not work around it. For tests use `_force_new=True`.
+The Python SDK is a **singleton per API key** — constructing twice with the same key returns the same live SDK. This is intentional; do not work around it. Different keys give different SDKs, so one process can serve several tenants. For tests use `_force_new=True`.
 
 **Critical:** every SDK call is async. Forgetting `await` is the #1 mistake.
 

--- a/skills/synap/reference/production.md
+++ b/skills/synap/reference/production.md
@@ -19,7 +19,7 @@ Work through this before the user's first production deployment, and again befor
 
 - [ ] `await sdk.initialize()` runs once at process start, not per-request.
 - [ ] `await sdk.shutdown()` runs on graceful shutdown (SIGTERM handler, FastAPI lifespan, Lambda extension, etc.).
-- [ ] Single SDK instance per `instance_id` per process — singleton behavior is intentional, don't fight it.
+- [ ] Single SDK instance per API key per process — singleton behavior is intentional, don't fight it. One key per instance: two keys on one instance give two SDKs and two streams.
 - [ ] In serverless, the SDK is module-level and initialized lazily on first invocation; cold-start latency is documented.
 
 ## Read path

--- a/skills/synap/reference/sdk-setup.md
+++ b/skills/synap/reference/sdk-setup.md
@@ -104,15 +104,21 @@ The JS API is flat and camelCase, and is **not** identical to Python: there is n
 
 ## Singleton behavior
 
-By design, constructing `MaximemSynapSDK` twice with the same `instance_id` returns the same instance:
+By design, constructing `MaximemSynapSDK` twice with the same **API key** returns the same live SDK:
 
 ```python
-a = MaximemSynapSDK(instance_id="inst_...", api_key="...")
-b = MaximemSynapSDK(instance_id="inst_...", api_key="...")
-assert a is b   # True
+a = MaximemSynapSDK(api_key="sk-...")
+b = MaximemSynapSDK(api_key="sk-...")
+# One live SDK: b shares a's connections, caches and credentials.
+# Note: `a is b` is False. They share internal state, they are not the same
+# object, so use the SDK rather than identity-checking it.
 ```
 
 This prevents duplicate connections from multi-module imports. Don't fight it. For tests, pass `_force_new=True`.
+
+Different API keys give you different SDKs, so serving several tenants from one process is supported. Two keys issued against the *same* instance are the exception: each key is its own identity, so you get two SDKs, two Listen streams and two caches for one instance. `initialize()` warns when it sees that. Use one key per instance per process.
+
+Passing `instance_id` explicitly still keys on the id, so two keys under one id share a single SDK on the first key. You do not need it: your API key already identifies your instance.
 
 ## Production-grade init with config
 


### PR DESCRIPTION
Pairs with `maximem_synap#955`. These files are **public-repo only** — `scripts/sync_to_public.sh` copies `synap/sdk/**` and `integrations/**`, not `skills/` — so they never received the correction that landed in the SDK and needed their own change.

## What was wrong

The SDK has keyed the singleton on the **credential** since 0.4.1. Before that, `instance_id` was empty at construction (it is only resolved from the API key during `initialize()`), so every SDK built the documented way collapsed onto one registry slot and the second construction silently adopted the first one's credentials. The skill files still described the old model.

`reference/sdk-setup.md` also asserted:

```python
assert a is b   # True
```

That was never true, before or after the fix. The two objects share `__dict__`; they are not identical. That snippet taught precisely the mental model that let the original bug hide in a debugger.

## Changes

| File | Change |
|---|---|
| `skills/synap/SKILL.md` | singleton per `instance_id` → per API key; notes different keys give different SDKs, so one process can serve several tenants |
| `skills/synap/AGENTS.md` | same one-liner corrected |
| `skills/synap/reference/sdk-setup.md` | rewrote "Singleton behavior": keys on the API key, removed the false identity assertion and replaced it with what actually holds, added the two-keys-one-instance case and what `instance_id` still does |
| `skills/synap/reference/production.md` | checklist item: single SDK per API key per process, plus one key per instance |
| `skills/synap-codex/reference/{sdk-setup,production}.md` | byte-identical mirrors, updated in step |

`skills/synap-codex/SKILL.md` and `AGENTS.md` turned out not to mention the singleton at all, so they needed nothing. A sweep confirms no `singleton per instance_id` or `assert a is b` remains anywhere in `skills/` or `README.md`.

## The two-keys case

Newly documented, because it is the one shape that surprises people: two API keys issued against the **same** instance are two identities, so you get two SDKs, two Listen streams and two caches. They are deliberately not merged, since merging would mean one caller transacting on the other's credential. `initialize()` warns when it detects it (see `maximem_synap#955`). Guidance is one key per instance per process.

🤖 Generated with [Claude Code](https://claude.com/claude-code)