### PR TITLE
sync: fix(sdk) cache instance scoping (0.4.3) + mcp<2 pin

### DIFF
--- a/packages/mcps/synap-mcp-server/Dockerfile
+++ b/packages/mcps/synap-mcp-server/Dockerfile
@@ -3,9 +3,18 @@ FROM python:3.11-slim
 WORKDIR /app
 
 # Dependencies only (no torch / no heavy ML deps — this is a thin adapter).
+#
+# NOTE: this list duplicates [project.dependencies] in pyproject.toml — the
+# COPY below is only there for layer invalidation, pip never reads it. Editing
+# pyproject alone changes nothing about the built image, so keep both in sync.
+#
+# The <2 bound is load-bearing: mcp 2.0 removed `mcp.server.fastmcp` (now
+# `mcp.server.mcpserver`), so server.py fails to import and this container
+# crash-loops while the rest of the stack reports healthy. Lift it only
+# together with migrating to the 2.0 API.
 COPY pyproject.toml ./
 RUN pip install --no-cache-dir \
-    "mcp[cli]>=1.26.0" \
+    "mcp[cli]>=1.26.0,<2" \
     "httpx>=0.27" \
     "uvicorn>=0.30" \
     "starlette>=0.37"

--- a/packages/mcps/synap-mcp-server/pyproject.toml
+++ b/packages/mcps/synap-mcp-server/pyproject.toml
@@ -4,7 +4,11 @@ version = "0.1.0"
 description = "Hosted remote MCP server (Streamable HTTP) adapter over the Synap public REST API."
 requires-python = ">=3.11"
 dependencies = [
-    "mcp[cli]>=1.26.0",
+    # Keep in sync with the Dockerfile, which duplicates this list and is the
+    # one pip actually reads. The <2 bound is load-bearing: mcp 2.0 removed
+    # `mcp.server.fastmcp`, so server.py fails to import and the container
+    # crash-loops while the rest of the stack reports healthy.
+    "mcp[cli]>=1.26.0,<2",
     "httpx>=0.27",
     "uvicorn>=0.30",
     "starlette>=0.37",

--- a/packages/sdks/maximem-synap/maximem_synap/_version.py
+++ b/packages/sdks/maximem-synap/maximem_synap/_version.py
@@ -1,3 +1,3 @@
 """Version information for MaximemSynap SDK."""
 
-__version__ = "0.4.2"
+__version__ = "0.4.3"

--- a/packages/sdks/maximem-synap/maximem_synap/cache/manager.py
+++ b/packages/sdks/maximem-synap/maximem_synap/cache/manager.py
@@ -21,12 +21,25 @@ class CacheManager:
     """Manages scoped caching with separate files per user/customer.
 
     File structure:
-    ~/.synap/{client_id}/
+    ~/.synap/{client_id}/{instance_id}/
     ├── client_cache.db              # Org-level context
     ├── customers/
     │   └── {customer_id}.db         # Customer-level context
     └── users/
         └── {user_id}.db             # User-level context (incl. conversations)
+
+    The instance segment matters because ``client_id`` identifies the Synap
+    *account*, not the memory store. One account can own several instances,
+    and they are separate memory stores with no data shared between them. Keyed
+    on ``client_id`` alone, two instances landed in the same directory and
+    their cache files were addressed by scope and entity id only — so the same
+    ``user_id`` or ``customer_id`` under two instances read and wrote the same
+    rows, and one instance could be served the other's cached context.
+
+    Empty ``instance_id`` keeps the legacy ``{client_id}`` path. The id is
+    resolved from the API key during ``initialize()``; when that lookup fails
+    there is nothing to scope by, and a process in that state can only have
+    one identity anyway.
     """
 
     # Default TTLs by scope (seconds)
@@ -42,14 +55,26 @@ class CacheManager:
         client_id: str,
         storage_path: Optional[str] = None,
         enabled: bool = True,
+        instance_id: str = "",
     ):
         self.client_id = client_id
+        self.instance_id = instance_id
         self.enabled = enabled
 
-        if storage_path:
-            self.base_path = Path(storage_path) / client_id
-        else:
-            self.base_path = Path.home() / ".synap" / client_id
+        root = Path(storage_path) if storage_path else Path.home() / ".synap"
+        self.base_path = root / client_id
+        if instance_id:
+            self.base_path = self.base_path / instance_id
+        elif enabled:
+            # Legacy, unscoped path. Reachable when whoami could not resolve
+            # the instance, and for anyone constructing CacheManager directly.
+            # Harmless for a single instance; two instances of one account
+            # would share these files, so say so rather than fail silently.
+            logger.warning(
+                "Cache is not instance-scoped (instance_id unknown); using %s. "
+                "Two instances of one account would share these files.",
+                self.base_path,
+            )
 
         # Cache of open backends by scope key
         self._backends: Dict[str, CacheBackend] = {}
@@ -91,12 +116,30 @@ class CacheManager:
     ) -> str:
         """Build cache key.
 
-        Format: {client_id}:{scope}:{entity_id}:{context_type}:{query_hash}
+        Format: {client_id}:{instance_id}:{scope}:{entity_id}:{context_type}:{query_hash}
+
+        The instance segment is belt-and-braces — per-instance directories
+        already keep the rows apart — but it makes a key self-describing in a
+        dump, and it means a file that somehow ends up shared cannot serve one
+        instance's row to another. Omitted when the instance is unknown, so
+        keys stay byte-identical to the legacy format on that path.
         """
-        parts = [self.client_id, scope.value, entity_id, context_type]
+        parts = [self._key_prefix(scope, entity_id).rstrip(":"), context_type]
         if query_hash:
             parts.append(query_hash)
         return ":".join(parts)
+
+    def _key_prefix(self, scope: CacheScope, entity_id: str) -> str:
+        """The leading, entity-identifying part of a key, ending in ``:``.
+
+        Single source of truth for key layout, shared by ``_build_key`` and by
+        the bulk-delete path so the two cannot drift apart.
+        """
+        parts = [self.client_id]
+        if self.instance_id:
+            parts.append(self.instance_id)
+        parts.extend([scope.value, entity_id])
+        return ":".join(parts) + ":"
 
     def _hash_query(self, query: Any) -> str:
         """Create deterministic hash of query parameters."""
@@ -186,8 +229,13 @@ class CacheManager:
             key = self._build_key(scope, entity_id, context_type, query_hash)
             backend.delete(key)
         else:
-            # Delete all entries for this entity
-            prefix = f"{self.client_id}:{scope.value}:{entity_id}:"
+            # Delete all entries for this entity. The prefix has to be built
+            # from the same parts as the key, in the same order — hand-rolling
+            # it here is how this silently stopped matching when the instance
+            # segment was added, and a bulk delete that matches nothing is a
+            # no-op that looks like success. Scoped to THIS instance, matching
+            # the key.
+            prefix = self._key_prefix(scope, entity_id)
             backend.clear_scope(prefix)
 
     def clear_user(self, user_id: str) -> None:

--- a/packages/sdks/maximem-synap/maximem_synap/sdk.py
+++ b/packages/sdks/maximem-synap/maximem_synap/sdk.py
@@ -1046,17 +1046,40 @@ class MaximemSynapSDK:
         ):
             if SDKRegistry.alias_if_absent(self.instance_id, self):
                 self._registry_alias_keys.append(self.instance_id)
+            else:
+                # The id is already taken by a different live SDK, which only
+                # happens when one process builds two SDKs that turn out to
+                # share an instance — most often two API keys issued against
+                # it. They are deliberately kept apart (merging them would
+                # mean one caller silently transacting on the other's
+                # credential, which is the bug this keying exists to prevent),
+                # but the duplication is invisible without saying so.
+                incumbent = SDKRegistry.get(self.instance_id)
+                if incumbent is not None and incumbent.__dict__ is not self.__dict__:
+                    logger.warning(
+                        "Instance %s already has a live SDK in this process. Both keep "
+                        "their own Listen stream and in-memory caches, and short-term "
+                        "context recorded through one is not visible to the other until "
+                        "the server round-trips it. Use one API key per instance per "
+                        "process if that was not intended.",
+                        self.instance_id,
+                    )
 
-        # Initialize cache (now that client_id is known)
+        # Initialize cache (now that client_id and instance_id are known).
+        # Both are needed: client_id is the account, instance_id is the memory
+        # store. One account can own several instances, so the cache has to be
+        # scoped by instance or two of them share files on disk.
         if self._config.cache_backend:
             self._cache_manager = CacheManager(
                 client_id=self._client_id,
+                instance_id=self.instance_id,
                 storage_path=self._config.storage_path,
                 enabled=True,
             )
         else:
             self._cache_manager = CacheManager(
                 client_id=self._client_id,
+                instance_id=self.instance_id,
                 enabled=False,
             )
 


### PR DESCRIPTION
Mirrors [maximem_synap#951](https://github.com/maximem-ai/maximem_synap/pull/951) and [#952](https://github.com/maximem-ai/maximem_synap/pull/952). Ships **0.4.3**.

Supersedes **#20** (bot sync of #951 alone — this carries the follow-up fix too) and, for the cache half, **#7**.

### The bug

The local cache lived at `~/.synap/{client_id}/` and addressed its files by scope and entity id alone. `client_id` identifies the Synap **account**, not the memory store, and one account can own several instances — separate memory stores sharing no data. Two instances under one account wrote to the same `users/{user_id}.db`:

```
  instance A wrote  : b'instance A private context'
  instance B reads  : b'instance A private context'
  BLEED: YES — B was served A's cached context
```

**Server-side scoping was never affected — local disk only.** It also needed two instances of one account live in the same process, which was broken until 0.4.1 and which 0.4.1/0.4.2 made both correct and the documented recommendation.

### The fix

`~/.synap/{client_id}/{instance_id}/`, with the instance in the cache key. An empty `instance_id` keeps the legacy path (whoami could not resolve the identity; such a process can only hold one anyway) and now logs a warning naming the shared directory, since `CacheManager` is publicly exported.

### The regression it caused, and who caught it

Adding the instance segment broke bulk delete — `delete(scope, entity)` with no `context_type` builds its prefix by hand, stopped matching the key, and cleared nothing. A no-op that looks like success. Key and prefix now come from one `_key_prefix()` so they cannot drift again.

**PR #7 fixed this whole area in June, with a staging-verified repro, and updated the delete prefix in the same change.** That is where the miss was found. #7's other half (`SYNAP_BASE_URL`) has since landed in the monorepo independently, so #7 is now fully superseded — worth closing with credit.

### Migration: none, deliberately

The cache starts cold and refills on demand. Old entries are **not** migrated: a pre-0.4.3 directory may hold entries from more than one instance with no way to tell which belongs to which, so moving them would carry the contamination forward. Nothing is deleted.

Also carries the MCP server's `mcp<2` pin ([#954](https://github.com/maximem-ai/maximem_synap/pull/954)).

| Check | Result |
|---|---|
| `tests/` | 70 passed |
| `synap-integrations-common` | 113 passed |
| test modules in the package | 0 |

