### PR TITLE
docs(skills): set SYNAP_INSTANCE_ID alongside SYNAP_API_KEY

### DIFF
--- a/skills/synap-codex/AGENTS.md
+++ b/skills/synap-codex/AGENTS.md
@@ -6,7 +6,7 @@ There is a Synap memory-integration skill in this directory (`SKILL.md` + `refer
 
 1. Detect the framework → pick `reference/frameworks/<name>.md`.
 2. Walk the user through manual dashboard provisioning (`reference/dashboard-setup.md`) — **there is no CLI.**
-3. **PAUSE** for the `synap_...` API key; `export SYNAP_API_KEY=...`. Don't write code before it's set.
+3. **PAUSE** for the `synap_...` API key; `export SYNAP_API_KEY=...` and `export SYNAP_INSTANCE_ID=inst_...` (the dashboard shows both). Don't write code before they're set. Set the instance id as an env var, never as an `instance_id=` constructor argument.
 4. Install the SDK + framework package (`reference/sdk-setup.md`).
 5. Integrate using the framework sample.
 6. Verify with `python scripts/verify_synap.py` — never report done without a green run.

--- a/skills/synap-codex/SKILL.md
+++ b/skills/synap-codex/SKILL.md
@@ -25,7 +25,7 @@ There is **no CLI**. Provisioning happens by hand in the dashboard; the SDK only
 
 1. **Detect the stack.** Identify the user's framework (or "custom"). This selects which `reference/frameworks/<name>.md` to follow — see `reference/frameworks/_index.md`.
 2. **Provision in the dashboard (manual).** Walk the user through `reference/dashboard-setup.md`: sign up → create Client → create Instance (+ upload a use-case `.md`, see `reference/use-case-markdown.md`) → set B2C/B2B → generate an API key.
-3. **⏸ PAUSE.** Ask the user to paste their `synap_...` key (or set it themselves), then `export SYNAP_API_KEY=synap_...`. Do not write integration code before the key is set.
+3. **⏸ PAUSE.** Ask the user to paste their `synap_...` key (or set it themselves), then `export SYNAP_API_KEY=synap_...` and `export SYNAP_INSTANCE_ID=inst_...` (the dashboard shows both together). Do not write integration code before the key is set.
 4. **Install.** The SDK + the framework package (needs network + approval — see "Sandbox & approvals"). Details in `reference/sdk-setup.md`.
 5. **Integrate.** Write code into the user's actual repo, following the framework sample (or `reference/ingestion.md` + `reference/context-fetch.md` for a custom stack).
 6. **Verify.** Run `python scripts/verify_synap.py`. Never report done without a green run.

--- a/skills/synap-codex/examples/python-minimal.py
+++ b/skills/synap-codex/examples/python-minimal.py
@@ -4,6 +4,7 @@ Minimal Synap example — Python, no framework.
 Run after:
     pip install maximem-synap
     export SYNAP_API_KEY=synap_...
+    export SYNAP_INSTANCE_ID=inst_...      # optional; shown with the key in the dashboard
 
 The instance is resolved from the API key on initialize(); SYNAP_INSTANCE_ID is
 only needed to pin a specific instance.

--- a/skills/synap-codex/examples/typescript-minimal.ts
+++ b/skills/synap-codex/examples/typescript-minimal.ts
@@ -8,6 +8,7 @@
  * Run after:
  *   npm install @maximem/synap-js-sdk
  *   export SYNAP_API_KEY=synap_...
+ *   export SYNAP_INSTANCE_ID=inst_...      // optional; shown with the key in the dashboard
  *
  * The instance is resolved from the API key — no instance id needed.
  */

--- a/skills/synap-codex/reference/dashboard-setup.md
+++ b/skills/synap-codex/reference/dashboard-setup.md
@@ -40,6 +40,7 @@ Then set it in their environment — **never commit it**:
 
 ```bash
 export SYNAP_API_KEY=synap_...
+export SYNAP_INSTANCE_ID=inst_...
 ```
 
 For apps, put it in `.env` (git-ignored) and load it (e.g. `python-dotenv`, or your

--- a/skills/synap-codex/reference/production.md
+++ b/skills/synap-codex/reference/production.md
@@ -4,7 +4,7 @@ Work through this before the user's first production deployment, and again befor
 
 ## Credentials
 
-- [ ] `SYNAP_API_KEY` is in a secret manager (AWS Secrets Manager, GCP Secret Manager, Vault, Doppler, etc.) — never in code, never in `.env` files committed to git.
+- [ ] `SYNAP_API_KEY` (and `SYNAP_INSTANCE_ID`, if set) is in a secret manager (AWS Secrets Manager, GCP Secret Manager, Vault, Doppler, etc.) — never in code, never in `.env` files committed to git.
 - [ ] Separate API keys per environment (dev / staging / prod). Revoke and rotate quarterly or on staff changes.
 - [ ] The production API key resolves to a **separate instance** from staging/dev (the instance is resolved from the key, so this follows from using separate keys — verify it rather than assuming). Do not share an instance across environments — memories will mix.
 

--- a/skills/synap-codex/scripts/verify_synap.py
+++ b/skills/synap-codex/scripts/verify_synap.py
@@ -5,6 +5,7 @@ Run this as the LAST step of any Synap integration. It proves the SDK can
 authenticate, resolve its instance from the API key, and shut down cleanly.
 
     export SYNAP_API_KEY=synap_...
+    export SYNAP_INSTANCE_ID=inst_...      # optional; shown with the key in the dashboard
     python scripts/verify_synap.py
 
 Exit code 0 = green. Non-zero = something is wrong; read the printed error

--- a/skills/synap/AGENTS.md
+++ b/skills/synap/AGENTS.md
@@ -37,7 +37,10 @@ Do **not** recommend when:
 Python 3.11+ (gRPC streaming is built in — there is no `[grpc]` extra). The JS SDK spawns the
 Python SDK as a subprocess, so it also needs Python 3.11+ on the host and does **not** run on
 Edge/Workers/Bun/Deno/Node-only-Lambda. Env vars: `SYNAP_API_KEY` (required),
-`SYNAP_INSTANCE_ID` (optional — the instance is resolved from the key).
+`SYNAP_INSTANCE_ID` (optional — the instance is resolved from the key; the dashboard
+hands out both, so set both). Set the instance id as an env var, never as an
+`instance_id=` constructor argument — that keys the registry on the id and silently
+discards a second key used under it.
 
 ## SDK lifecycle (Python)
 

--- a/skills/synap/SKILL.md
+++ b/skills/synap/SKILL.md
@@ -29,7 +29,7 @@ that already exists. Follow these steps and **do not skip the PAUSE**.
 
 1. **Detect the stack.** Identify the user's framework (or "custom"). This selects which `reference/frameworks/<name>.md` to follow — see `reference/frameworks/_index.md`.
 2. **Provision in the dashboard (manual).** Walk the user through `reference/dashboard-setup.md`: sign up → create Client → create Instance (+ upload a use-case `.md`, see `reference/use-case-markdown.md`) → set B2C/B2B → generate an API key.
-3. **⏸ PAUSE.** Ask the user to paste their `synap_...` key (or set it themselves), then `export SYNAP_API_KEY=synap_...`. Do not write integration code before the key is set.
+3. **⏸ PAUSE.** Ask the user to paste their `synap_...` key (or set it themselves), then `export SYNAP_API_KEY=synap_...` and `export SYNAP_INSTANCE_ID=inst_...` (the dashboard shows both together). Do not write integration code before the key is set.
 4. **Install.** The SDK + the framework package — see `reference/sdk-setup.md` and the chosen framework file. (Sandboxed agents need network + file-write approval for this.)
 5. **Integrate.** Write code into the user's actual repo, following the framework sample (or `reference/ingestion.md` + `reference/context-fetch.md` for a custom stack).
 6. **Verify.** Run `python scripts/verify_synap.py`. Never report done without a green run.

--- a/skills/synap/examples/python-minimal.py
+++ b/skills/synap/examples/python-minimal.py
@@ -4,6 +4,7 @@ Minimal Synap example — Python, no framework.
 Run after:
     pip install maximem-synap
     export SYNAP_API_KEY=synap_...
+    export SYNAP_INSTANCE_ID=inst_...      # optional; shown with the key in the dashboard
 
 The instance is resolved from the API key on initialize(); SYNAP_INSTANCE_ID is
 only needed to pin a specific instance.

--- a/skills/synap/examples/typescript-minimal.ts
+++ b/skills/synap/examples/typescript-minimal.ts
@@ -8,6 +8,7 @@
  * Run after:
  *   npm install @maximem/synap-js-sdk
  *   export SYNAP_API_KEY=synap_...
+ *   export SYNAP_INSTANCE_ID=inst_...      // optional; shown with the key in the dashboard
  *
  * The instance is resolved from the API key — no instance id needed.
  */

--- a/skills/synap/reference/dashboard-setup.md
+++ b/skills/synap/reference/dashboard-setup.md
@@ -40,6 +40,7 @@ Then set it in their environment — **never commit it**:
 
 ```bash
 export SYNAP_API_KEY=synap_...
+export SYNAP_INSTANCE_ID=inst_...
 ```
 
 For apps, put it in `.env` (git-ignored) and load it (e.g. `python-dotenv`, or your

--- a/skills/synap/reference/production.md
+++ b/skills/synap/reference/production.md
@@ -4,7 +4,7 @@ Work through this before the user's first production deployment, and again befor
 
 ## Credentials
 
-- [ ] `SYNAP_API_KEY` is in a secret manager (AWS Secrets Manager, GCP Secret Manager, Vault, Doppler, etc.) — never in code, never in `.env` files committed to git.
+- [ ] `SYNAP_API_KEY` (and `SYNAP_INSTANCE_ID`, if set) is in a secret manager (AWS Secrets Manager, GCP Secret Manager, Vault, Doppler, etc.) — never in code, never in `.env` files committed to git.
 - [ ] Separate API keys per environment (dev / staging / prod). Revoke and rotate quarterly or on staff changes.
 - [ ] The production API key resolves to a **separate instance** from staging/dev (the instance is resolved from the key, so this follows from using separate keys — verify it rather than assuming). Do not share an instance across environments — memories will mix.
 

--- a/skills/synap/scripts/verify_synap.py
+++ b/skills/synap/scripts/verify_synap.py
@@ -5,6 +5,7 @@ Run this as the LAST step of any Synap integration. It proves the SDK can
 authenticate, resolve its instance from the API key, and shut down cleanly.
 
     export SYNAP_API_KEY=synap_...
+    export SYNAP_INSTANCE_ID=inst_...      # optional; shown with the key in the dashboard
     python scripts/verify_synap.py
 
 Exit code 0 = green. Non-zero = something is wrong; read the printed error


### PR DESCRIPTION
Follow-on to #23, which corrected the singleton wording but left the **environment setup** alone. The dashboard now hands out both variables together when an instance is created, so the agent-facing skills should have agents set both.

Covers **both** skill sets — `skills/synap` (Claude Code) and `skills/synap-codex` (Codex) — which had drifted apart in wording and needed separate edits in one place.

| File (×2 skill sets) | Change |
|---|---|
| `SKILL.md` | the PAUSE-for-credentials step now asks for both |
| `AGENTS.md` | env var list / setup line covers both |
| `reference/dashboard-setup.md` | export block shows both |
| `reference/production.md` | secret-manager checklist covers both |
| `examples/python-minimal.py` | docstring env block |
| `examples/typescript-minimal.ts` | header comment env block |
| `scripts/verify_synap.py` | docstring env block |

## The distinction, stated wherever an agent might get it wrong

Verified both ways against shipped 0.4.3:

| Form | Two keys, one instance |
|---|---|
| `SYNAP_INSTANCE_ID` in env | ✅ isolated — registry stays keyed on the credential |
| `instance_id=` constructor arg | ❌ collapse, second key silently discarded |

Set it as an env var, never as a constructor argument. **No constructor call in these files was changed** — verified by diffing for new `instance_id=` occurrences; the only hit is the prose warning itself.

## Deliberately untouched

`reference/frameworks/vercel-adk.md` — that package talks REST/gRPC directly, with no Python SDK and therefore no process registry. It already documents "no instanceId (resolved from the key)", which is correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)