### PR TITLE
sync: feat(requests): second latency column — server-side processing time (#971)

### DIFF
--- a/packages/integrations/synap-camel-ai/pyproject.toml
+++ b/packages/integrations/synap-camel-ai/pyproject.toml
@@ -18,6 +18,13 @@ dependencies = [
     "maximem-synap>=0.2.0",
     "maximem-synap-integrations-common>=0.1.0",
     "camel-ai>=0.2.90",
+    # Same load-bearing <2 bound as synap-mcp-server (#954): mcp 2.0 removed
+    # `mcp.server.fastmcp`, and camel-ai's own `camel/toolkits/base.py` does
+    # `from mcp.server import FastMCP` at class-body time — so importing
+    # anything under `camel.toolkits` explodes against mcp 2.x. camel-ai
+    # leaves mcp unpinned, so without this bound pip resolves 2.x and every
+    # import of this package fails.
+    "mcp<2",
 ]
 
 [project.optional-dependencies]

--- a/packages/sdks/maximem-synap/maximem_synap/_version.py
+++ b/packages/sdks/maximem-synap/maximem_synap/_version.py
@@ -1,3 +1,3 @@
 """Version information for MaximemSynap SDK."""
 
-__version__ = "0.4.4"
+__version__ = "0.4.5"

--- a/packages/sdks/maximem-synap/maximem_synap/transport/http_client.py
+++ b/packages/sdks/maximem-synap/maximem_synap/transport/http_client.py
@@ -464,17 +464,28 @@ class HTTPTransport:
         into telemetry events.
         """
         if response.status_code == 204:
-            return {"status_code": 204, "body_size": 0}
+            payload: Dict[str, Any] = {"status_code": 204, "body_size": 0}
+        else:
+            try:
+                body_size = len(response.content)
+            except Exception:
+                body_size = -1
+            payload = {
+                "status_code": response.status_code,
+                "body_size": body_size,
+            }
 
-        try:
-            body_size = len(response.content)
-        except Exception:
-            body_size = -1
+        # Server-side processing time stamped by the API (middleware header,
+        # server >= 2026-08-08). Reported so the dashboard can show server
+        # latency next to the SDK's wall-clock; absent on older servers.
+        server_ms = response.headers.get("x-synap-server-ms")
+        if server_ms is not None:
+            try:
+                payload["server_latency_ms"] = int(float(server_ms))
+            except (TypeError, ValueError):
+                pass
 
-        return {
-            "status_code": response.status_code,
-            "body_size": body_size,
-        }
+        return payload
 
     def _emit_telemetry(self, **kwargs) -> None:
         """Emit telemetry event if callback configured."""


### PR DESCRIPTION
Automated SDK sync from `maximem-ai/maximem_synap@e184efc`.

Generated by `sync_sdk_to_public.yml` via `scripts/sync_to_public.sh`. Review the diff and merge; do not hand-edit these files in this repo, the next sync overwrites them.